### PR TITLE
Fix ObjC code linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,11 @@ if (WIN32)
   endif()
 endif()
 
+if (APPLE)
+  find_library(COCOA Cocoa REQUIRED)
+  list(APPEND DEPENDENCIES_LIBRARIES ${COCOA})
+endif()
+
 if (NOT MSVC)
   set(WARNING_FLAGS -Wall -Wextra -Wno-unused-parameter)
   if (WARNINGS_ARE_ERRORS)


### PR DESCRIPTION
[macstuff.m depends on Cocoa](https://github.com/tildearrow/furnace/blob/36787cb33e9ea53e5e29753360e329dbe951ea1a/src/gui/macstuff.m#L1) but we never link against it, instead we hope that the compiling environment understands that we *meant* to link against it. In some environments (i.e. my Nix build environment on macOS 10.13), this is not enough and throws a linking error due to missing Cocoa symbols:

![Bildschirmfoto von 2022-02-10 12-20-29](https://user-images.githubusercontent.com/23431373/153403068-90f93894-7dca-464e-aae4-4e704e8b1c95.png)

This PR fixes the Cocoa linking omission.