### PR TITLE
Tell MSVC source files are in UTF-8 format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ if (NOT MSVC)
   endif()
 else()
   # /wd4100 == -Wno-unused-parameter
+  add_compile_options("/source-charset:utf-8")
   set(WARNING_FLAGS /W4 /wd4100 /D_CRT_SECURE_NO_WARNINGS)
   if (WARNINGS_ARE_ERRORS)
     list(APPEND WARNING_FLAGS /WX)


### PR DESCRIPTION
On some locales (e.g. Japanese) MSVC will fail to build Furnace because it makes an incorrect assumption about the encoding of source files.  In particular, string literals in engine.cpp cause
compile errors.  This probably doesn't show up in CI because of the difference in locale.

This patch adds the `/source-charset:utf-8` compiler flag for MSVC, which tells it the encoding of the source files.

With this change, MSVC appears to build Furnace properly.  Tested with Visual Studio Professional 2022.