### PR TITLE
Add AY-3-8914 support as configurable in AY-3-8910

### DIFF
--- a/papers/doc/7-systems/ay8910.md
+++ b/papers/doc/7-systems/ay8910.md
@@ -4,6 +4,8 @@ this chip was used in several home computers (ZX Spectrum, MSX, Amstrad CPC, Ata
 
 the chip's powerful sound comes from the envelope...
 
+AY-3-8914 variant was used in Intellivision, it's basically original AY with 4 level envelope volume per channel and different register format.
+
 # effects
 
 - `20xx`: set channel mode. `xx` may be one of the following:

--- a/src/engine/platform/ay.h
+++ b/src/engine/platform/ay.h
@@ -26,6 +26,10 @@
 
 class DivPlatformAY8910: public DivDispatch {
   protected:
+    const unsigned char AY8914RegRemap[16]={
+      0,4,1,5,2,6,9,8,11,12,13,3,7,10,14,15
+    };
+    inline unsigned char regRemap(unsigned char reg) { return intellivision?AY8914RegRemap[reg&0x0f]:reg&0x0f; }
     struct Channel {
       unsigned char freqH, freqL;
       int freq, baseFreq, note, pitch;
@@ -60,7 +64,7 @@ class DivPlatformAY8910: public DivDispatch {
     int delay;
 
     bool extMode;
-    bool stereo, sunsoft;
+    bool stereo, sunsoft, intellivision;
   
     short oldWrites[16];
     short pendingWrites[16];

--- a/src/engine/sysDef.cpp
+++ b/src/engine/sysDef.cpp
@@ -419,10 +419,6 @@ const char* DivEngine::getSongSystemName() {
             return "Vectrex";
           case 5: // AY-3-8910, 1MHz
             return "Amstrad CPC";
-          case 6: // AY-3-8910, 0.somethingMhz
-            return "Intellivision";
-          case 8: // AY-3-8910, 0.somethingMhz
-            return "Intellivision (PAL)";
 
           case 0x10: // YM2149, 1.79MHz
             return "MSX";
@@ -432,7 +428,12 @@ const char* DivEngine::getSongSystemName() {
             return "Sunsoft 5B standalone";
           case 0x28: // 5B PAL
             return "Sunsoft 5B standalone (PAL)";
-          
+
+          case 0x30: // AY-3-8914, 1.79MHz
+            return "Intellivision";
+          case 0x33: // AY-3-8914, 2MHz
+            return "Intellivision (PAL)";
+
           default:
             if ((song.systemFlags[0]&0x30)==0x00) {
               return "AY-3-8910";
@@ -440,6 +441,8 @@ const char* DivEngine::getSongSystemName() {
               return "Yamaha YM2149";
             } else if ((song.systemFlags[0]&0x30)==0x20) {
               return "Overclocked Sunsoft 5B";
+            } else if ((song.systemFlags[0]&0x30)==0x30) {
+              return "Intellivision";
             }
         }
       } else if (song.system[0]==DIV_SYSTEM_SMS) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -5116,6 +5116,10 @@ bool FurnaceGUI::loop() {
                     e->setSysFlags(i,(flags&(~0x30))|32,restart);
                     updateWindowTitle();
                   }
+                  if (ImGui::RadioButton("AY-3-8914",(flags&0x30)==48)) {
+                    e->setSysFlags(i,(flags&(~0x30))|48,restart);
+                    updateWindowTitle();
+                  }
                 }
                 bool stereo=flags&0x40;
                 ImGui::BeginDisabled((flags&0x30)==32);
@@ -6684,7 +6688,7 @@ FurnaceGUI::FurnaceGUI():
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "Mattel Intellivision", {
-      DIV_SYSTEM_AY8910, 64, 0, 6,
+      DIV_SYSTEM_AY8910, 64, 0, 48,
       0
     }
   ));


### PR DESCRIPTION
It's basically AY-3-8910 with 4 level envelope volume per voice and different register format, so not 1:1 compatible with original.
Original Intellivision used this, Later revision also exists.

Some infos are based on http://wiki.intellivision.us/index.php/PSG .

Example(WIP prototype): https://www.youtube.com/watch?v=RJ7IVwqjnvI