### PR TITLE
Lynx panning swap

### DIFF
--- a/src/engine/platform/lynx.cpp
+++ b/src/engine/platform/lynx.cpp
@@ -235,7 +235,7 @@ int DivPlatformLynx::dispatch(DivCommand c) {
       }
       break;
     case DIV_CMD_PANNING:
-      chan[c.chan].pan=((c.value&0x0f)<<4)|((c.value&0xf0)>>4);
+      chan[c.chan].pan=c.value;
       WRITE_ATTEN(c.chan,chan[c.chan].pan);
       break;
     case DIV_CMD_GET_VOLUME:

--- a/src/engine/platform/sound/lynx/Mikey.cpp
+++ b/src/engine/platform/sound/lynx/Mikey.cpp
@@ -435,8 +435,8 @@ public:
       case ATTENREG2:
       case ATTENREG3:
         mRegisterPool[8*4+idx] = value;
-        mAttenuationLeft[idx] = ( value & 0x0f ) << 2;
-        mAttenuationRight[idx] = ( value & 0xf0 ) >> 2;
+        mAttenuationRight[idx] = ( value & 0x0f ) << 2;
+        mAttenuationLeft[idx] = ( value & 0xf0 ) >> 2;
         break;
       case MPAN:
         mPan = value;


### PR DESCRIPTION
I've discovered that the panning is reversed on the real hardware.
Here's the fix.