### PR TITLE
Fix precision errors in frequency calculation

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -815,22 +815,22 @@ void DivEngine::playSub(bool preserveDrift, int goalRow) {
   cmdStream.clear();
 }
 
-int DivEngine::calcBaseFreq(double clock, double divider, int note, bool period) {
+double DivEngine::calcBaseFreq(double clock, double divider, int note, bool period) {
   double base=(period?(song.tuning*0.0625):song.tuning)*pow(2.0,(float)(note+3)/12.0);
   return period?
-         round((clock/base)/divider):
+         (clock/base)/divider:
          base*(divider/clock);
 }
 
-int DivEngine::calcFreq(int base, int pitch, bool period, int octave) {
+int DivEngine::calcFreq(double base, double pitch, bool period, int octave) {
   if (song.linearPitch) {
-    return period?
-            base*pow(2,-(double)pitch/(12.0*128.0))/(98.0+globalPitch*6.0)*98.0:
-            (base*pow(2,(double)pitch/(12.0*128.0))*(98+globalPitch*6))/98;
+    return round(period?
+            base*pow(2,-pitch/(12.0*128.0))/(98.0+globalPitch*6.0)*98.0:
+            (base*pow(2,pitch/(12.0*128.0))*(98.0+globalPitch*6))/98.0);
   }
-  return period?
+  return round(period?
            base-pitch:
-           base+((pitch*octave)>>1);
+           base+((pitch*octave)/2.0));
 }
 
 void DivEngine::play() {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -320,10 +320,10 @@ class DivEngine {
     void setConf(String key, String value);
 
     // calculate base frequency/period
-    int calcBaseFreq(double clock, double divider, int note, bool period);
+    double calcBaseFreq(double clock, double divider, int note, bool period);
 
     // calculate frequency/period
-    int calcFreq(int base, int pitch, bool period=false, int octave=0);
+    int calcFreq(double base, double pitch, bool period=false, int octave=0);
 
     // find song loop position
     void walkSong(int& loopOrder, int& loopRow, int& loopEnd);


### PR DESCRIPTION
This improves chips with very low frequency ranges, especially VERA PCM where it has to multiply C-4 offset after calcBaseFreq calls. Also fixes calcFreq(32, 0, true, 0) returning 31 due to the 0.1+0.2 error.