### PR TITLE
Add support of N163 demultiplexed output

### DIFF
--- a/src/engine/platform/n163.cpp
+++ b/src/engine/platform/n163.cpp
@@ -156,7 +156,7 @@ const char* DivPlatformN163::getEffectName(unsigned char effect) {
 void DivPlatformN163::acquire(short* bufL, short* bufR, size_t start, size_t len) {
   for (size_t i=start; i<start+len; i++) {
     n163.tick();
-    int out=((n163.out()<<6)*2); // scale to 16 bit
+    int out=(n163.out()<<6)*2; // scale to 16 bit
     if (out>32767) out=32767;
     if (out<-32768) out=-32768;
     bufL[i]=bufR[i]=out;

--- a/src/engine/platform/n163.cpp
+++ b/src/engine/platform/n163.cpp
@@ -156,7 +156,7 @@ const char* DivPlatformN163::getEffectName(unsigned char effect) {
 void DivPlatformN163::acquire(short* bufL, short* bufR, size_t start, size_t len) {
   for (size_t i=start; i<start+len; i++) {
     n163.tick();
-    int out=(n163.out()<<6)*2; // scale to 16 bit
+    int out=((n163.out()<<6)*2); // scale to 16 bit
     if (out>32767) out=32767;
     if (out<-32768) out=-32768;
     bufL[i]=bufR[i]=out;
@@ -607,6 +607,7 @@ void DivPlatformN163::reset() {
   memset(regPool,0,128);
 
   n163.set_disable(false);
+  n163.set_multiplex(multiplex);
   chanMax=initChanMax;
   loadWave=-1;
   loadPos=0;
@@ -636,8 +637,10 @@ void DivPlatformN163::setFlags(unsigned int flags) {
       break;
   }
   initChanMax=chanMax=(flags>>4)&7;
+  multiplex=((flags>>7)&1)?false:true; // not accurate in real hardware
   chipClock=rate;
   rate/=15;
+  n163.set_multiplex(multiplex);
   rWrite(0x7f,initChanMax<<4);
 }
 

--- a/src/engine/platform/n163.h
+++ b/src/engine/platform/n163.h
@@ -75,6 +75,7 @@ class DivPlatformN163: public DivDispatch {
   unsigned char chanMax;
   short loadWave, loadPos, loadLen;
   unsigned char loadMode;
+  bool multiplex;
 
   n163_core n163;
   unsigned char regPool[128];

--- a/src/engine/platform/sound/n163/n163.hpp
+++ b/src/engine/platform/sound/n163/n163.hpp
@@ -48,6 +48,7 @@ public:
 
 	// register pool
 	u8 reg(u8 addr) { return m_ram[addr & 0x7f]; }
+	void set_multiplex(bool multiplex = true) { m_multiplex = multiplex; }
 
 private:
 	// Address latch
@@ -73,6 +74,9 @@ private:
 	u8 m_voice_cycle = 0x78; // Voice cycle for processing
 	addr_latch_t m_addr_latch; // address latch
 	s16 m_out = 0; // output
+	// demultiplex related
+	bool m_multiplex = true; // multiplex flag, but less noisy = inaccurate!
+	s16 m_acc = 0; // accumulated output
 };
 
 #endif

--- a/src/gui/sysConf.cpp
+++ b/src/gui/sysConf.cpp
@@ -372,6 +372,11 @@ void FurnaceGUI::drawSysConf(int i) {
         e->setSysFlags(i,(flags & ~(7 << 4)) | (((initialChannelLimit-1) & 7) << 4),restart);
         updateWindowTitle();
       } rightClickable
+      bool n163Multiplex=flags&128;
+      if (ImGui::Checkbox("Disable Multiplexed Output",&n163Multiplex)) {
+        e->setSysFlags(i,(flags&(~128))|(n163Multiplex<<7),restart);
+        updateWindowTitle();
+      }
       break;
     }
     case DIV_SYSTEM_GB:


### PR DESCRIPTION
for test purpose.
so, there's to way for reduce N163 noises: reduce channel limit and demultiplex
* channel limit is runtime changeable and it makes some usable effects with disable demultiplex
* demultiplex is used for "non-ear destroyable" emulators, but less hardware accurate. (when LPF and RF filter is not considered)
Furnace support both after this, You can choose output behavior via configuration flag.

<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->
