### PR TITLE
Add Export for Commander X16 ZSM music file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,8 @@ src/engine/sysDef.cpp
 src/engine/wavetable.cpp
 src/engine/waveSynth.cpp
 src/engine/vgmOps.cpp
+src/engine/zsmOps.cpp
+src/engine/zsm.cpp
 src/engine/platform/abstract.cpp
 src/engine/platform/genesis.cpp
 src/engine/platform/genesisext.cpp

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -326,6 +326,8 @@ class DivEngine {
     SafeWriter* buildROM(int sys);
     // dump to VGM.
     SafeWriter* saveVGM(bool* sysToExport=NULL, bool loop=true, int version=0x171);
+    // dump to ZSM.
+    SafeWriter* saveZSM(unsigned int zsmrate=60, bool loop=true);
     // export to an audio file
     bool saveAudio(const char* path, int loops, DivAudioExportModes mode);
     // wait for audio export to finish

--- a/src/engine/platform/vera.cpp
+++ b/src/engine/platform/vera.cpp
@@ -27,7 +27,9 @@ extern "C" {
   #include "sound/vera_pcm.h"
 }
 
-#define rWrite(c,a,d) {regPool[(c)*4+(a)]=(d); psg_writereg(psg,((c)*4+(a)),(d));}
+//if (dumpWrites) {addWrite(((c)*4+(a)),(d));}
+//#define rWrite(c,a,d) {regPool[(c)*4+(a)]=(d); psg_writereg(psg,((c)*4+(a)),(d));}
+#define rWrite(c,a,d) {regPool[(c)*4+(a)]=(d); psg_writereg(psg,((c)*4+(a)),(d));if (dumpWrites) {addWrite(((c)*4+(a)),(d));}}
 #define rWriteLo(c,a,d) rWrite(c,a,(regPool[(c)*4+(a)]&(~0x3f))|((d)&0x3f))
 #define rWriteHi(c,a,d) rWrite(c,a,(regPool[(c)*4+(a)]&(~0xc0))|(((d)<<6)&0xc0))
 #define rWritePCMCtrl(d) {regPool[64]=(d); pcm_write_ctrl(pcm,d);}

--- a/src/engine/zsm.cpp
+++ b/src/engine/zsm.cpp
@@ -1,0 +1,155 @@
+/**
+ * Furnace Tracker - multi-system chiptune tracker
+ * Copyright (C) 2021-2022 tildearrow and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "zsm.h"
+#include "../ta-log.h"
+#include "../utfutils.h"
+#include "song.h"
+
+ZSM::ZSM() {
+  w = NULL;
+  init();
+}
+
+ZSM::~ZSM() {
+}
+
+void ZSM::init(unsigned int rate) {
+  if (w != NULL) {
+	delete w;
+  }
+  w = new SafeWriter;
+  w->init();
+  // write blank ZSM magic header & data header
+  if (ZSM_MAGIC_HDR_SIZE==2) w->write("ZM",2);
+  w->writeS(0x00);
+  w->writeC(0xff); // default to no-loop header
+  w->writeC(0x00);
+  w->writeI(0x00);
+  w->writeC(0x00);
+  w->writeS((unsigned short)rate);
+  w->writeC(0x00);
+  w->writeI(0x00);
+  tickRate = rate;
+  loopOffset=-1;
+  numWrites=0;
+  memset(&ymState,-1,sizeof(ymState));
+  memset(&psgState,-1,sizeof(psgState));
+  ticks=0;
+}
+
+int ZSM::getoffset() {
+  return w->tell();
+}
+
+void ZSM::writeYM(unsigned char a, unsigned char v) {
+  numWrites++;
+  ymwrites.push_back(DivRegWrite(a,v));
+  // update YM shadow even though we're not yet de-duping YM writes....
+  if (a==0x19 && v>=0x80) a=0x1a; // AMD/PSD use same reg addr. store PMD as 0x1a
+  if (a!=0x08) {
+	ymState[ym_NEW][a] = v;
+  }
+}
+
+void ZSM::writePSG(unsigned char a, unsigned char v) {
+  if(psgState[psg_PREV][a] == v) {
+	if (psgState[psg_NEW][a] != v)
+	  numWrites--;
+  } else {
+    if (psgState[psg_PREV][a] == psgState[psg_NEW][a])
+      numWrites++;
+  }
+  psgState[psg_NEW][a] = v;
+}
+
+void ZSM::writePCM(unsigned char a, unsigned char v) {
+  // ZSM standard for PCM playback has not been established yet.
+}
+
+void ZSM::tick(int numticks) {
+  if (numWrites > 0) {
+    flushTicks();
+    flushWrites();
+  }
+  ticks += numticks;
+}
+
+void ZSM::setLoopPoint() {
+  tick(0); // flush any ticks+writes
+  flushTicks(); // flush ticks if no writes
+  logI("ZSM: loop at file offset %d bytes",w->tell());
+  loopOffset=w->tell()-ZSM_MAGIC_HDR_SIZE;
+  w->seek(0+ZSM_MAGIC_HDR_SIZE,SEEK_SET);
+  w->writeS((short)(loopOffset%0x2000));
+  w->writeC((short)loopOffset/0x2000);
+  w->seek(loopOffset+ZSM_MAGIC_HDR_SIZE,SEEK_SET);
+  memset(&psgState,-1,sizeof(psgState));
+}
+
+SafeWriter* ZSM::finish() {
+  tick(0);
+  flushTicks();
+  w->writeC(ZSM_EOF);
+  // todo: put PCM offset/data writes here once defined in ZSM standard.
+  // todo: set channel-use bitmasks in header
+  return w;
+}
+
+void ZSM::flushWrites() {
+  if (numWrites==0) return;
+  for (int i=0;i<64;i++) {
+	if (psgState[psg_NEW][i] == psgState[psg_PREV][i]) continue;
+	psgState[psg_PREV][i]=psgState[psg_NEW][i];
+	w->writeC(i);
+	w->writeC(psgState[psg_NEW][i]);
+  }
+  int n=0;
+  for (DivRegWrite& write: ymwrites) {
+	if (n%ZSM_YM_MAX_WRITES == 0) {
+      if(ymwrites.size()-n > ZSM_YM_MAX_WRITES) {
+		w->writeC(ZSM_YM_CMD+ZSM_YM_MAX_WRITES);
+		logD("ZSM: YM-write: %d (%02x) [max]",ZSM_YM_MAX_WRITES,ZSM_YM_MAX_WRITES+ZSM_YM_CMD);
+	  } else {
+		w->writeC(ZSM_YM_CMD+ymwrites.size()-n);
+		logD("ZSM: YM-write: %d (%02x)",ymwrites.size()-n,ZSM_YM_CMD+ymwrites.size()-n);
+	  }
+    }
+    n++;
+    w->writeC(write.addr);
+    w->writeC(write.val);
+  }
+  ymwrites.clear();
+  ticks=0;
+  numWrites=0;
+}
+
+void ZSM::flushTicks() {
+  while (ticks > ZSM_DELAY_MAX) {
+	logD("ZSM: write delay %d (max)",ZSM_DELAY_MAX);
+	w->writeC(ZSM_DELAY_CMD+ZSM_DELAY_MAX);
+	ticks -= ZSM_DELAY_MAX;
+  }
+  if (ticks>0) {
+	logD("ZSM: write delay %d",ticks);
+	w->writeC(ZSM_DELAY_CMD+ticks);
+  }
+  ticks=0;
+}
+	

--- a/src/engine/zsm.h
+++ b/src/engine/zsm.h
@@ -1,0 +1,65 @@
+/**
+ * Furnace Tracker - multi-system chiptune tracker
+ * Copyright (C) 2021-2022 tildearrow and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+ 
+#ifndef _ZSM_H
+#define _ZSM_H
+
+//#include "engine.h"
+#include "safeWriter.h"
+#include "dispatch.h"
+#include <stdlib.h>
+
+#define ZSM_MAGIC_HDR_SIZE 2
+#define ZSM_HEADER_SIZE 16
+#define ZSM_YM_CMD 0x40
+#define ZSM_DELAY_CMD 0x80
+#define ZSM_YM_MAX_WRITES 63
+#define ZSM_DELAY_MAX 127
+#define ZSM_EOF ZSM_DELAY_CMD
+
+enum YM_STATE { ym_PREV, ym_NEW, ym_STATES };
+enum PSG_STATE { psg_PREV, psg_NEW, psg_STATES };
+
+class ZSM {
+  private:
+	SafeWriter* w;
+	int ymState[ym_STATES][256];
+	int psgState[psg_STATES][64];
+	std::vector<DivRegWrite> ymwrites;
+	int loopOffset;
+	int numWrites;
+	int ticks;
+	int tickRate;
+  public:
+	ZSM();
+	~ZSM();
+	void init(unsigned int rate = 60);
+	int getoffset();
+	void writeYM(unsigned char a, unsigned char v);
+	void writePSG(unsigned char a, unsigned char v);
+	void writePCM(unsigned char a, unsigned char v);
+	void tick(int numticks = 1);
+	void setLoopPoint();
+	SafeWriter* finish();
+  private:
+    void flushWrites();
+    void flushTicks();
+};
+
+#endif

--- a/src/engine/zsmOps.cpp
+++ b/src/engine/zsmOps.cpp
@@ -1,0 +1,166 @@
+/**
+ * Furnace Tracker - multi-system chiptune tracker
+ * Copyright (C) 2021-2022 tildearrow and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "engine.h"
+#include "../ta-log.h"
+#include "../utfutils.h"
+#include "song.h"
+#include "zsm.h"
+
+constexpr int MASTER_CLOCK_PREC=(sizeof(void*)==8)?8:0;
+
+SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop) {
+
+  int VERA = -1;
+  int YM = -1;
+  int IGNORED = 0;
+  
+  //loop = false;
+  // find indexes for YM and VERA. Ignore other systems.
+  for (int i=0; i<song.systemLen; i++) {
+	switch (song.system[i]) {
+	  case DIV_SYSTEM_VERA:
+	    if (VERA >= 0) { IGNORED++;break; }
+	    VERA = i;
+	    logD("VERA detected as chip id %d",i);
+	    break;
+	  case DIV_SYSTEM_YM2151:
+	    if (YM >= 0) { IGNORED++;break; }
+	    YM = i;
+	    logD("YM detected as chip id %d",i);
+	    break;
+	  default:
+	    IGNORED++;
+	    logD("Ignoring chip %d systemID %d",i,song.system[i]);
+	}
+  }
+  if (VERA < 0 && YM < 0) {
+	logE("No supported systems for ZSM");
+	return NULL;
+  }
+  if (IGNORED > 0)
+    logW("ZSM export ignoring %d unsupported systems",IGNORED);
+  
+  stop();
+  repeatPattern=false;
+  setOrder(0);
+  BUSY_BEGIN_SOFT;
+
+  double origRate=got.rate;
+  got.rate=zsmrate & 0xffff;
+  
+  // determine loop point
+  int loopOrder=0;
+  int loopRow=0;
+  int loopEnd=0;
+  walkSong(loopOrder,loopRow,loopEnd);
+  logI("loop point: %d %d",loopOrder,loopRow);
+  warnings="";
+
+  ZSM zsm;
+  zsm.init(zsmrate);
+  curOrder=0;
+  freelance=false;
+  playing=false;
+  extValuePresent=false;
+  remainingLoops=-1;
+
+  // write song data
+  playSub(false);
+  size_t tickCount=0;
+//  bool writeLoop=false;
+  bool done=false;
+  int loopPos=-1;
+//  int loopTick=-1;
+  int writeCount=0;
+
+  if (VERA >= 0) disCont[VERA].dispatch->toggleRegisterDump(true);
+  if (YM >= 0) disCont[YM].dispatch->toggleRegisterDump(true);
+ 
+  while (!done) {
+    if (loopPos==-1) {
+      if (loopOrder==curOrder && loopRow==curRow && ticks==1 && loop) {
+		loopPos=zsm.getoffset();
+        zsm.setLoopPoint();
+      }
+    }
+    if (nextTick() || !playing) {
+      done=true;
+      if (!loop) {
+        for (int i=0; i<song.systemLen; i++) {
+          disCont[i].dispatch->getRegisterWrites().clear();
+        }
+        break;
+      }  
+      if (!playing) {
+//        writeLoop=false;
+        loopPos=-1;
+      }
+    }
+    // get register dumps
+    for (int j=0; j<2; j++) {
+	  int i=0;
+	  if (j==0) {
+	    if (YM < 0)
+	      continue;
+	    else
+	      i=YM;
+	  }
+	  if (j==1) {
+	    if (VERA < 0)
+	      continue;
+	    else {
+		  i=VERA;
+	    }
+	  }
+      std::vector<DivRegWrite>& writes=disCont[i].dispatch->getRegisterWrites();
+      if (writes.size() > 0) logD("zsmOps: Writing %d messages to chip %d",writes.size(), i);
+      for (DivRegWrite& write: writes) {
+        if (i==0) zsm.writeYM(write.addr&0xff, write.val);
+        if (i==1) zsm.writePSG(write.addr&0xff, write.val);
+        writeCount++;
+      }
+      writes.clear();
+    }
+
+    // write wait
+    int totalWait=cycles>>MASTER_CLOCK_PREC;
+    if (totalWait>0) {
+      zsm.tick(totalWait);
+      tickCount+=totalWait;
+    }
+  }
+  // end of song
+  // done - close out.
+  
+  got.rate = origRate;
+  disCont[VERA].dispatch->toggleRegisterDump(false);
+  disCont[YM].dispatch->toggleRegisterDump(false);
+  
+  remainingLoops=-1;
+  playing=false;
+  freelance=false;
+  extValuePresent=false;
+
+  logI("%d register writes total.",writeCount);
+
+  BUSY_END;
+  return zsm.finish();
+ 
+}

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -72,6 +72,7 @@ enum FurnaceGUIColors {
   GUI_COLOR_FILE_AUDIO,
   GUI_COLOR_FILE_WAVE,
   GUI_COLOR_FILE_VGM,
+  GUI_COLOR_FILE_ZSM,
   GUI_COLOR_FILE_FONT,
   GUI_COLOR_FILE_OTHER,
 
@@ -242,6 +243,7 @@ enum FurnaceGUIFileDialogs {
   GUI_FILE_EXPORT_AUDIO_PER_SYS,
   GUI_FILE_EXPORT_AUDIO_PER_CHANNEL,
   GUI_FILE_EXPORT_VGM,
+  GUI_FILE_EXPORT_ZSM,
   GUI_FILE_EXPORT_ROM,
   GUI_FILE_LOAD_MAIN_FONT,
   GUI_FILE_LOAD_PAT_FONT,
@@ -709,14 +711,15 @@ class FurnaceGUI {
   bool updateSampleTex;
 
   String workingDir, fileName, clipboard, warnString, errorString, lastError, curFileName, nextFile;
-  String workingDirSong, workingDirIns, workingDirWave, workingDirSample, workingDirAudioExport, workingDirVGMExport, workingDirFont, workingDirColors, workingDirKeybinds, workingDirLayout;
+  String workingDirSong, workingDirIns, workingDirWave, workingDirSample, workingDirAudioExport, workingDirVGMExport, workingDirZSMexport, workingDirFont, workingDirColors, workingDirKeybinds, workingDirLayout;
   String mmlString[17];
   String mmlStringW;
 
-  bool quit, warnQuit, willCommit, edit, modified, displayError, displayExporting, vgmExportLoop, wantCaptureKeyboard;
+  bool quit, warnQuit, willCommit, edit, modified, displayError, displayExporting, vgmExportLoop, zsmExportLoop, wantCaptureKeyboard;
   bool displayNew, fullScreen;
   bool willExport[32];
   int vgmExportVersion;
+  int zsmExportTickRate;
   int drawHalt;
 
   FurnaceGUIFileDialogs curFileDialog;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -711,7 +711,7 @@ class FurnaceGUI {
   bool updateSampleTex;
 
   String workingDir, fileName, clipboard, warnString, errorString, lastError, curFileName, nextFile;
-  String workingDirSong, workingDirIns, workingDirWave, workingDirSample, workingDirAudioExport, workingDirVGMExport, workingDirZSMexport, workingDirFont, workingDirColors, workingDirKeybinds, workingDirLayout;
+  String workingDirSong, workingDirIns, workingDirWave, workingDirSample, workingDirAudioExport, workingDirVGMExport, workingDirZSMExport, workingDirFont, workingDirColors, workingDirKeybinds, workingDirLayout;
   String mmlString[17];
   String mmlStringW;
 

--- a/src/gui/guiConst.cpp
+++ b/src/gui/guiConst.cpp
@@ -377,6 +377,7 @@ const FurnaceGUIColorDef guiColors[GUI_COLOR_MAX]={
   D(GUI_COLOR_FILE_AUDIO,"",ImVec4(1.0f,1.0f,0.5f,1.0f)),
   D(GUI_COLOR_FILE_WAVE,"",ImVec4(1.0f,0.75f,0.5f,1.0f)),
   D(GUI_COLOR_FILE_VGM,"",ImVec4(1.0f,1.0f,0.5f,1.0f)),
+  D(GUI_COLOR_FILE_ZSM,"",ImVec4(1.0f,1.0f,0.5f,1.0f)),
   D(GUI_COLOR_FILE_FONT,"",ImVec4(0.3f,1.0f,0.6f,1.0f)),
   D(GUI_COLOR_FILE_OTHER,"",ImVec4(0.7f,0.7f,0.7f,1.0f)),
 

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -1053,6 +1053,7 @@ void FurnaceGUI::drawSettings() {
             UI_COLOR_CONFIG(GUI_COLOR_FILE_AUDIO,"Audio");
             UI_COLOR_CONFIG(GUI_COLOR_FILE_WAVE,"Wavetable");
             UI_COLOR_CONFIG(GUI_COLOR_FILE_VGM,"VGM");
+            UI_COLOR_CONFIG(GUI_COLOR_FILE_ZSM,"ZSM");
             UI_COLOR_CONFIG(GUI_COLOR_FILE_FONT,"Font");
             UI_COLOR_CONFIG(GUI_COLOR_FILE_OTHER,"Other");
             ImGui::TreePop();
@@ -2467,6 +2468,7 @@ void FurnaceGUI::applyUISettings(bool updateFonts) {
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".wav",uiColors[GUI_COLOR_FILE_AUDIO],ICON_FA_FILE_AUDIO_O);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".dmc",uiColors[GUI_COLOR_FILE_AUDIO],ICON_FA_FILE_AUDIO_O);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".vgm",uiColors[GUI_COLOR_FILE_VGM],ICON_FA_FILE_AUDIO_O);
+  ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".zsm",uiColors[GUI_COLOR_FILE_ZSM],ICON_FA_FILE_AUDIO_O);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".ttf",uiColors[GUI_COLOR_FILE_FONT],ICON_FA_FONT);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".otf",uiColors[GUI_COLOR_FILE_FONT],ICON_FA_FONT);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".ttc",uiColors[GUI_COLOR_FILE_FONT],ICON_FA_FONT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ FurnaceGUI g;
 
 String outName;
 String vgmOutName;
+String zsmOutName;
 int loops=1;
 DivAudioExportModes outMode=DIV_EXPORT_MODE_ONE;
 
@@ -213,6 +214,12 @@ bool pVGMOut(String val) {
   return true;
 }
 
+bool pZSMOut(String val) {
+  zsmOutName=val;
+  e.setAudio(DIV_AUDIO_DUMMY);
+  return true;
+}
+
 bool needsValue(String param) {
   for (size_t i=0; i<params.size(); i++) {
     if (params[i].name==param) {
@@ -228,6 +235,7 @@ void initParams() {
   params.push_back(TAParam("a","audio",true,pAudio,"jack|sdl","set audio engine (SDL by default)"));
   params.push_back(TAParam("o","output",true,pOutput,"<filename>","output audio to file"));
   params.push_back(TAParam("O","vgmout",true,pVGMOut,"<filename>","output .vgm data"));
+  params.push_back(TAParam("Z","zsmout",true,pZSMOut,"<filename>","output .zsm data for Commander X16 Zsound"));
   params.push_back(TAParam("L","loglevel",true,pLogLevel,"debug|info|warning|error","set the log level (info by default)"));
   params.push_back(TAParam("v","view",true,pView,"pattern|commands|nothing","set visualization (pattern by default)"));
   params.push_back(TAParam("c","console",false,pConsole,"","enable console mode"));
@@ -251,6 +259,7 @@ int main(int argc, char** argv) {
 #endif
   outName="";
   vgmOutName="";
+  zsmOutName="";
 
   initParams();
 


### PR DESCRIPTION
<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->
Commander X16 system VERA was recently added. This PR enables Furnace to export tracks in a format ZSM which has full native support for the specific systems present in the Commander X16.