### PR TITLE
Fix more MSVC warnings

### DIFF
--- a/src/winMain.cpp
+++ b/src/winMain.cpp
@@ -31,16 +31,3 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prevInst, PSTR args, int state) {
   }
   return main(argc,argv);
 }
-
-int WINAPI wWinMain(HINSTANCE inst, HINSTANCE prevInst, PWSTR args, int state) {
-  int argc=0;
-  wchar_t** argw=CommandLineToArgvW(args,&argc);
-  char** argv=new char*[argc+1];
-  argv[argc]=NULL;
-  for (int i=0; i<argc; i++) {
-    std::string str=utf16To8(argw[i]);
-    argv[i]=new char[str.size()+1];
-    strcpy(argv[i],str.c_str());
-  }
-  return main(argc,argv);
-}


### PR DESCRIPTION
~~Draft because I don't have access to a Windows system myself.~~

---

- Only one graphical entry point may be defined, otherwise the linker is
  confused and has to implicitly make a decision on which one to use.
  WinMain has CLAs as ANSI strings, wWinMain as Unicode ones.
  We're not passing -municode on MinGW and both MSVC & MinGW default to WinMain.
