### PR TITLE
More #79 - OPM, Y12, OPLI, OPNI import

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -291,13 +291,10 @@ class DivEngine {
   void loadSBI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadOPLI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadOPNI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
-  void loadPAT(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadY12(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadBNK(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadFF(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
-  void loadWOPL(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
-  void loadWOPN(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
 
   bool initAudioBackend();
   bool deinitAudioBackend();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <map>
 #include <queue>
+#include <sstream>
 
 #define addWarning(x) \
   if (warnings.empty()) { \
@@ -288,9 +289,15 @@ class DivEngine {
   void loadVGI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadS3I(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadSBI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
+  void loadOPLI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
+  void loadOPNI(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
+  void loadPAT(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
+  void loadY12(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadBNK(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
   void loadFF(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
+  void loadWOPL(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
+  void loadWOPN(SafeReader& reader, std::vector<DivInstrument*>& ret, String& stripPath);
 
   bool initAudioBackend();
   bool deinitAudioBackend();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -31,7 +31,6 @@
 #include <mutex>
 #include <map>
 #include <queue>
-#include <sstream>
 
 #define addWarning(x) \
   if (warnings.empty()) { \

--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -829,12 +829,15 @@ void DivEngine::loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, St
        c1Read = false,
        m2Read = false,
        c2Read = false;
+
+  DivInstrument* newPatch = nullptr;
   
   auto completePatchRead = [&]() {
     return patchNameRead && lfoRead && characteristicRead && m1Read && c1Read && m2Read && c2Read;
   };
   auto resetPatchRead = [&]() {
     patchNameRead = lfoRead = characteristicRead = m1Read = c1Read = m2Read = c2Read = false;
+    newPatch = nullptr;
   };
   auto readOpmOperator = [](SafeReader& reader, DivInstrumentFM::Operator& op) {
     op.ar = atoi(reader.readString_Token().c_str());
@@ -849,8 +852,6 @@ void DivEngine::loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, St
     op.dt2 = atoi(reader.readString_Token().c_str());
     op.ssgEnv = atoi(reader.readString_Token().c_str());
   };
-
-  DivInstrument* newPatch = nullptr;
 
   try {
     reader.seek(0, SEEK_SET);
@@ -922,7 +923,7 @@ void DivEngine::loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, St
 
       if (completePatchRead()) {
         insList.push_back(newPatch);
-        newPatch = nullptr;
+        resetPatchRead();
         ++readCount;
       }
     }

--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -650,12 +650,12 @@ void DivEngine::loadY12(SafeReader& reader, std::vector<DivInstrument*>& ret, St
     ins->fm.ops = 4;
     ins->name = stripPath;
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i : {0,1,2,3}) {
       DivInstrumentFM::Operator& insOp = ins->fm.op[i];
       uint8_t tmp = reader.readC();
       insOp.mult = (tmp & 0xF);
       insOp.dt = ((tmp >> 4) & 0x7);
-      insOp.tl = (reader.readC() & 0xF);
+      insOp.tl = (reader.readC() & 0x3F);
       tmp = reader.readC();
       insOp.rs = ((tmp >> 6) & 0x3);
       insOp.ar = (tmp & 0x1F);
@@ -671,7 +671,7 @@ void DivEngine::loadY12(SafeReader& reader, std::vector<DivInstrument*>& ret, St
     }
     ins->fm.alg = reader.readC();
     ins->fm.fb = reader.readC();
-    reader.seek(14, SEEK_CUR);
+    reader.seek(62, SEEK_CUR);
     ret.push_back(ins);
   } catch (EndOfFileException& e) {
     lastError = "premature end of file";

--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -818,11 +818,15 @@ void DivEngine::loadY12(SafeReader& reader, std::vector<DivInstrument*>& ret, St
       insOp.rr = tmp & 0xF;
       insOp.sl = ((tmp >> 4) & 0xF);
       insOp.ssgEnv = reader.readC();
-      reader.seek(9, SEEK_CUR);
+      if (!reader.seek(9, SEEK_CUR)) {
+        throw EndOfFileException(&reader, reader.tell() + 9);
+      }
     }
     ins->fm.alg = reader.readC();
     ins->fm.fb = reader.readC();
-    reader.seek(62, SEEK_CUR);
+    if (!reader.seek(62, SEEK_CUR)) {
+      throw EndOfFileException(&reader, reader.tell() + 62);
+    }
     ret.push_back(ins);
   } catch (EndOfFileException& e) {
     lastError="premature end of file";
@@ -858,7 +862,9 @@ void DivEngine::loadBNK(SafeReader& reader, std::vector<DivInstrument*>& ret, St
       }
 
       // Seek to BNK data
-      reader.seek(data_offset, SEEK_SET);
+      if (!reader.seek(data_offset, SEEK_SET)) {
+        throw EndOfFileException(&reader, data_offset);
+      };
 
       // Read until EOF
       for (int i = 0; i < readCount; ++i) {

--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -801,7 +801,7 @@ void DivEngine::loadY12(SafeReader& reader, std::vector<DivInstrument*>& ret, St
     ins->fm.ops = 4;
     ins->name = stripPath;
 
-    for (int i; i < 4; ++i) {
+    for (int i = 0; i < 4; ++i) {
       DivInstrumentFM::Operator& insOp = ins->fm.op[i];
       uint8_t tmp = reader.readC();
       insOp.mult = tmp & 0xF;

--- a/src/engine/safeReader.cpp
+++ b/src/engine/safeReader.cpp
@@ -165,7 +165,7 @@ String SafeReader::readString() {
   return ret;
 }
 
-String SafeReader::readString_Line() {
+String SafeReader::readStringLine() {
   String ret;
   unsigned char c;
   if (isEOF()) throw EndOfFileException(this, len);
@@ -179,7 +179,7 @@ String SafeReader::readString_Line() {
   return ret;
 }
 
-String SafeReader::readString_Token(unsigned char delim) {
+String SafeReader::readStringToken(unsigned char delim) {
   String ret;
   unsigned char c;
   if (isEOF()) throw EndOfFileException(this, len);
@@ -198,12 +198,11 @@ String SafeReader::readString_Token(unsigned char delim) {
   }
   return ret;
 }
-String SafeReader::readString_Token() {
-  return readString_Token(' ');
+
+String SafeReader::readStringToken() {
+  return readStringToken(' ');
 }
 
-
-
-bool SafeReader::isEOF() {
+inline bool SafeReader::isEOF() {
   return curSeek >= len;
 }

--- a/src/engine/safeReader.cpp
+++ b/src/engine/safeReader.cpp
@@ -139,7 +139,7 @@ double SafeReader::readD() {
 }
 
 String SafeReader::readString(size_t stlen) {
-  String ret(stlen, ' ');
+  String ret;
 #ifdef READ_DEBUG
   logD("SR: reading string len %d at %x",stlen,curSeek);
 #endif

--- a/src/engine/safeReader.cpp
+++ b/src/engine/safeReader.cpp
@@ -202,7 +202,3 @@ String SafeReader::readStringToken(unsigned char delim) {
 String SafeReader::readStringToken() {
   return readStringToken(' ');
 }
-
-inline bool SafeReader::isEOF() {
-  return curSeek >= len;
-}

--- a/src/engine/safeReader.cpp
+++ b/src/engine/safeReader.cpp
@@ -198,6 +198,11 @@ String SafeReader::readString_Token(unsigned char delim) {
   }
   return ret;
 }
+String SafeReader::readString_Token() {
+  return readString_Token(' ');
+}
+
+
 
 bool SafeReader::isEOF() {
   return curSeek >= len;

--- a/src/engine/safeReader.h
+++ b/src/engine/safeReader.h
@@ -69,7 +69,7 @@ class SafeReader {
     String readStringLine();
     String readStringToken(unsigned char delim);
     String readStringToken();
-    inline bool isEOF();
+    bool isEOF();
 
     SafeReader(void* b, size_t l):
       buf((unsigned char*)b),

--- a/src/engine/safeReader.h
+++ b/src/engine/safeReader.h
@@ -69,7 +69,7 @@ class SafeReader {
     String readStringLine();
     String readStringToken(unsigned char delim);
     String readStringToken();
-    bool isEOF();
+    inline bool isEOF() { return curSeek >= len; };
 
     SafeReader(void* b, size_t l):
       buf((unsigned char*)b),

--- a/src/engine/safeReader.h
+++ b/src/engine/safeReader.h
@@ -66,10 +66,10 @@ class SafeReader {
     double readD_BE();
     String readString();
     String readString(size_t len);
-    String readString_Line();
-    String readString_Token(unsigned char delim);
-    String readString_Token();
-    bool isEOF();
+    String readStringLine();
+    String readStringToken(unsigned char delim);
+    String readStringToken();
+    inline bool isEOF();
 
     SafeReader(void* b, size_t l):
       buf((unsigned char*)b),

--- a/src/engine/safeReader.h
+++ b/src/engine/safeReader.h
@@ -66,6 +66,9 @@ class SafeReader {
     double readD_BE();
     String readString();
     String readString(size_t len);
+    String readString_Line();
+    String readString_Token(unsigned char delim=' ');
+    bool isEOF();
 
     SafeReader(void* b, size_t l):
       buf((unsigned char*)b),

--- a/src/engine/safeReader.h
+++ b/src/engine/safeReader.h
@@ -67,7 +67,8 @@ class SafeReader {
     String readString();
     String readString(size_t len);
     String readString_Line();
-    String readString_Token(unsigned char delim=' ');
+    String readString_Token(unsigned char delim);
+    String readString_Token();
     bool isEOF();
 
     SafeReader(void* b, size_t l):

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1290,9 +1290,9 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       if (!dirExists(workingDirIns)) workingDirIns=getHomeDir();
       hasOpened=fileDialog->openLoad(
         "Load Instrument",
-        {"compatible files", "*.fui *.dmp *.tfi *.vgi *.s3i *.sbi *.bnk *.ff",
+        {"compatible files", "*.fui *.dmp *.tfi *.vgi *.s3i *.sbi *.bnk *.ff *.opm",
          "all files", ".*"},
-        "compatible files{.fui,.dmp,.tfi,.vgi,.s3i,.sbi,.bnk,.ff},.*",
+        "compatible files{.fui,.dmp,.tfi,.vgi,.s3i,.sbi,.bnk,.ff,.opm},.*",
         workingDirIns,
         dpiScale
       );

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1290,9 +1290,9 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       if (!dirExists(workingDirIns)) workingDirIns=getHomeDir();
       hasOpened=fileDialog->openLoad(
         "Load Instrument",
-        {"compatible files", "*.fui *.dmp *.tfi *.vgi *.s3i *.sbi *.bnk *.ff *.opm",
+        {"compatible files", "*.fui *.dmp *.tfi *.vgi *.s3i *.sbi *.y12 *.bnk *.ff *.opm",
          "all files", ".*"},
-        "compatible files{.fui,.dmp,.tfi,.vgi,.s3i,.sbi,.bnk,.ff,.opm},.*",
+        "compatible files{.fui,.dmp,.tfi,.vgi,.s3i,.sbi,.y12,.bnk,.ff,.opm},.*",
         workingDirIns,
         dpiScale
       );

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1290,9 +1290,9 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       if (!dirExists(workingDirIns)) workingDirIns=getHomeDir();
       hasOpened=fileDialog->openLoad(
         "Load Instrument",
-        {"compatible files", "*.fui *.dmp *.tfi *.vgi *.s3i *.sbi *.y12 *.bnk *.ff *.opm",
+        {"compatible files", "*.fui *.dmp *.tfi *.vgi *.s3i *.sbi *.opli *.opni *.y12 *.bnk *.ff *.opm",
          "all files", ".*"},
-        "compatible files{.fui,.dmp,.tfi,.vgi,.s3i,.sbi,.y12,.bnk,.ff,.opm},.*",
+        "compatible files{.fui,.dmp,.tfi,.vgi,.s3i,.sbi,.opli,.opni,.y12,.bnk,.ff,.opm},.*",
         workingDirIns,
         dpiScale
       );

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -2485,6 +2485,8 @@ void FurnaceGUI::applyUISettings(bool updateFonts) {
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".vgi",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".s3i",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".sbi",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
+  ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".opli",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
+  ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".opni",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".y12",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".bnk",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".fti",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -2485,6 +2485,7 @@ void FurnaceGUI::applyUISettings(bool updateFonts) {
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".vgi",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".s3i",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".sbi",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
+  ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".y12",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".bnk",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".fti",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".bti",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -2489,6 +2489,7 @@ void FurnaceGUI::applyUISettings(bool updateFonts) {
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".fti",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".bti",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".ff",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
+  ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".opm",uiColors[GUI_COLOR_FILE_INSTR],ICON_FA_FILE);
 
   if (updateFonts) {
     if (fileDialog!=NULL) delete fileDialog;


### PR DESCRIPTION
More on #79:
- Complete OPM load support (also added to `SafeReader` class with some basic text reading helpers).
- Add Wohlstand OPLI and OPNI patch loading support
    - *Note:* OPLI Pseudo 4-op (2x2op) detune offset must be applied manually. These will load as 2x 2op patch pairs.
- Add Gens KMod .y12 patch dump (Kaneda format) support.
