### PR TITLE
Fix horizontal scroll direction on macOS.

### DIFF
--- a/extern/imgui_patched/imgui_impl_sdl.cpp
+++ b/extern/imgui_patched/imgui_impl_sdl.cpp
@@ -300,6 +300,9 @@ bool ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event)
         {
             float wheel_x = (event->wheel.x > 0) ? 1.0f : (event->wheel.x < 0) ? -1.0f : 0.0f;
             float wheel_y = (event->wheel.y > 0) ? 1.0f : (event->wheel.y < 0) ? -1.0f : 0.0f;
+#ifdef __APPLE__
+            wheel_x = -wheel_x;
+#endif
             io.AddMouseWheelEvent(wheel_x, wheel_y);
             return true;
         }


### PR DESCRIPTION
Without this patch, scrolling horizontally with the track pad is inverted.

See open Dear ImGUI issue:
https://github.com/ocornut/imgui/issues/4019

This patches it for macOS in the local copy of imgui_impl_sdl.