### PR TITLE
Move renderSamples() to DivDispatch implementations.

### DIFF
--- a/src/engine/dispatch.h
+++ b/src/engine/dispatch.h
@@ -439,6 +439,26 @@ class DivDispatch {
     virtual const char** getRegisterSheet();
 
     /**
+     * Get sample memory buffer.
+     */
+    virtual const void* getSampleMem(int index = 0);
+
+    /**
+     * Get sample memory capacity.
+     */
+    virtual size_t getSampleMemCapacity(int index = 0);
+
+    /**
+     * Get sample memory usage.
+     */
+    virtual size_t getSampleMemUsage(int index = 0);
+
+    /**
+     * Render samples into sample memory.
+     */
+    virtual void renderSamples();
+
+    /**
      * initialize this DivDispatch.
      * @param parent the parent DivEngine.
      * @param channels the number of channels to acquire.

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -422,6 +422,7 @@ class DivEngine {
     DivInstrument* getIns(int index, DivInstrumentType fallbackType=DIV_INS_FM);
     DivWavetable* getWave(int index);
     DivSample* getSample(int index);
+    DivDispatch* getDispatch(int index);
     // parse system setup description
     String encodeSysDesc(std::vector<int>& desc);
     std::vector<int> decodeSysDesc(String desc);
@@ -849,19 +850,6 @@ class DivEngine {
     // terminate the engine.
     bool quit();
 
-    unsigned char* adpcmAMem;
-    size_t adpcmAMemLen;
-    unsigned char* adpcmBMem;
-    size_t adpcmBMemLen;
-    unsigned char* qsoundMem;
-    size_t qsoundMemLen;
-    unsigned char* qsoundAMem;
-    size_t qsoundAMemLen;
-    unsigned char* dpcmMem;
-    size_t dpcmMemLen;
-    unsigned char* x1_010Mem;
-    size_t x1_010MemLen;
-
     DivEngine():
       output(NULL),
       exportThread(NULL),
@@ -935,19 +923,7 @@ class DivEngine {
       oscSize(1),
       oscReadPos(0),
       oscWritePos(0),
-      tickMult(1),
-      adpcmAMem(NULL),
-      adpcmAMemLen(0),
-      adpcmBMem(NULL),
-      adpcmBMemLen(0),
-      qsoundMem(NULL),
-      qsoundMemLen(0),
-      qsoundAMem(NULL),
-      qsoundAMemLen(0),
-      dpcmMem(NULL),
-      dpcmMemLen(0),
-      x1_010Mem(NULL),
-      x1_010MemLen(0) {
+      tickMult(1) {
       memset(isMuted,0,DIV_MAX_CHANS*sizeof(bool));
       memset(keyHit,0,DIV_MAX_CHANS*sizeof(bool));
       memset(dispatchChanOfChan,0,DIV_MAX_CHANS*sizeof(int));

--- a/src/engine/fileOps.cpp
+++ b/src/engine/fileOps.cpp
@@ -899,12 +899,14 @@ bool DivEngine::loadDMF(unsigned char* file, size_t len) {
     song.unload();
     song=ds;
     recalcChans();
-    renderSamples();
     saveLock.unlock();
     BUSY_END;
     if (active) {
       initDispatch();
-      syncReset();
+      BUSY_BEGIN;
+      renderSamples();
+      reset();
+      BUSY_END;
     }
   } catch (EndOfFileException& e) {
     logE("premature end of file!");
@@ -1596,12 +1598,14 @@ bool DivEngine::loadFur(unsigned char* file, size_t len) {
     song.unload();
     song=ds;
     recalcChans();
-    renderSamples();
     saveLock.unlock();
     BUSY_END;
     if (active) {
       initDispatch();
-      syncReset();
+      BUSY_BEGIN;
+      renderSamples();
+      reset();
+      BUSY_END;
     }
   } catch (EndOfFileException& e) {
     logE("premature end of file!");
@@ -2005,12 +2009,14 @@ bool DivEngine::loadMod(unsigned char* file, size_t len) {
     song.unload();
     song=ds;
     recalcChans();
-    renderSamples();
     saveLock.unlock();
     BUSY_END;
     if (active) {
       initDispatch();
-      syncReset();
+      BUSY_BEGIN;
+      renderSamples();
+      reset();
+      BUSY_END;
     }
     success=true;
   } catch (EndOfFileException& e) {

--- a/src/engine/platform/abstract.cpp
+++ b/src/engine/platform/abstract.cpp
@@ -141,6 +141,22 @@ const char** DivDispatch::getRegisterSheet() {
   return NULL;
 }
 
+const void* DivDispatch::getSampleMem(int index) {
+  return NULL;
+}
+
+size_t DivDispatch::getSampleMemCapacity(int index) {
+  return 0;
+}
+
+size_t DivDispatch::getSampleMemUsage(int index) {
+  return 0;
+}
+
+void DivDispatch::renderSamples() {
+  
+}
+
 int DivDispatch::init(DivEngine* p, int channels, int sugRate, unsigned int flags) {
   return 0;
 }

--- a/src/engine/platform/qsound.h
+++ b/src/engine/platform/qsound.h
@@ -67,6 +67,8 @@ class DivPlatformQSound: public DivDispatch {
   int echoDelay;
   int echoFeedback;
 
+  unsigned char* sampleMem;
+  size_t sampleMemLen;
   struct qsound_chip chip;
   unsigned short regPool[512];
 
@@ -94,6 +96,10 @@ class DivPlatformQSound: public DivDispatch {
     void poke(std::vector<DivRegWrite>& wlist);
     const char** getRegisterSheet();
     const char* getEffectName(unsigned char effect);
+    const void* getSampleMem(int index = 0);
+    size_t getSampleMemCapacity(int index = 0);
+    size_t getSampleMemUsage(int index = 0);
+    void renderSamples();
     int init(DivEngine* parent, int channels, int sugRate, unsigned int flags);
     void quit();
 };

--- a/src/engine/platform/x1_010.h
+++ b/src/engine/platform/x1_010.h
@@ -28,13 +28,13 @@
 
 class DivX1_010Interface: public x1_010_mem_intf {
   public:
-    DivEngine* parent;
+    unsigned char* memory;
     int sampleBank;
     virtual u8 read_byte(u32 address) override {
-      if (parent->x1_010Mem==NULL) return 0;
-      return parent->x1_010Mem[address & 0xfffff];
+      if (memory==NULL) return 0;
+      return memory[address & 0xfffff];
     }
-    DivX1_010Interface(): parent(NULL), sampleBank(0) {}
+    DivX1_010Interface(): memory(NULL), sampleBank(0) {}
 };
 
 class DivPlatformX1_010: public DivDispatch {
@@ -115,6 +115,8 @@ class DivPlatformX1_010: public DivDispatch {
   DivDispatchOscBuffer* oscBuf[16];
   bool isMuted[16];
   bool stereo=false;
+  unsigned char* sampleMem;
+  size_t sampleMemLen;
   unsigned char sampleBank;
   DivX1_010Interface intf;
   x1_010_core* x1_010;
@@ -141,6 +143,10 @@ class DivPlatformX1_010: public DivDispatch {
     void notifyInsDeletion(void* ins);
     void poke(unsigned int addr, unsigned short val);
     void poke(std::vector<DivRegWrite>& wlist);
+    const void* getSampleMem(int index = 0);
+    size_t getSampleMemCapacity(int index = 0);
+    size_t getSampleMemUsage(int index = 0);
+    void renderSamples();
     const char** getRegisterSheet();
     const char* getEffectName(unsigned char effect);
     int init(DivEngine* parent, int channels, int sugRate, unsigned int flags);

--- a/src/engine/platform/ym2610.h
+++ b/src/engine/platform/ym2610.h
@@ -27,14 +27,32 @@
 
 class DivYM2610Interface: public ymfm::ymfm_interface {
   public:
-    DivEngine* parent;
+    unsigned char* adpcmAMem;
+    unsigned char* adpcmBMem;
     int sampleBank;
     uint8_t ymfm_external_read(ymfm::access_class type, uint32_t address);
     void ymfm_external_write(ymfm::access_class type, uint32_t address, uint8_t data);
-    DivYM2610Interface(): parent(NULL), sampleBank(0) {}
+    DivYM2610Interface(): adpcmAMem(NULL), adpcmBMem(NULL), sampleBank(0) {}
 };
 
-class DivPlatformYM2610: public DivDispatch {
+class DivPlatformYM2610Base: public DivDispatch {
+  protected:
+    unsigned char* adpcmAMem;
+    size_t adpcmAMemLen;
+    unsigned char* adpcmBMem;
+    size_t adpcmBMemLen;
+    DivYM2610Interface iface;
+
+  public:
+    const void* getSampleMem(int index);
+    size_t getSampleMemCapacity(int index);
+    size_t getSampleMemUsage(int index);
+    void renderSamples();
+    int init(DivEngine* parent, int channels, int sugRate, unsigned int flags);
+    void quit();
+};
+
+class DivPlatformYM2610: public DivPlatformYM2610Base {
   protected:
     const unsigned short chanOffs[4]={
       0x01, 0x02, 0x101, 0x102
@@ -93,7 +111,6 @@ class DivPlatformYM2610: public DivDispatch {
     std::queue<QueuedWrite> writes;
     ymfm::ym2610* fm;
     ymfm::ym2610::output_data fmout;
-    DivYM2610Interface iface;
 
     DivPlatformAY8910* ay;
     unsigned char regPool[512];

--- a/src/engine/platform/ym2610Interface.cpp
+++ b/src/engine/platform/ym2610Interface.cpp
@@ -24,13 +24,11 @@
 uint8_t DivYM2610Interface::ymfm_external_read(ymfm::access_class type, uint32_t address) {
   switch (type) {
     case ymfm::ACCESS_ADPCM_A:
-      if (parent->adpcmAMem==NULL) return 0;
-      if ((address&0xffffff)>=parent->adpcmAMemLen) return 0;
-      return parent->adpcmAMem[address&0xffffff];
+      if (adpcmAMem==NULL) return 0;
+      return adpcmAMem[address&0xffffff];
     case ymfm::ACCESS_ADPCM_B:
-      if (parent->adpcmBMem==NULL) return 0;
-      if ((address&0xffffff)>=parent->adpcmBMemLen) return 0;
-      return parent->adpcmBMem[address&0xffffff];
+      if (adpcmBMem==NULL) return 0;
+      return adpcmBMem[address&0xffffff];
     default:
       return 0;
   }

--- a/src/engine/platform/ym2610b.cpp
+++ b/src/engine/platform/ym2610b.cpp
@@ -1243,7 +1243,7 @@ void DivPlatformYM2610B::setSkipRegisterWrites(bool value) {
 }
 
 int DivPlatformYM2610B::init(DivEngine* p, int channels, int sugRate, unsigned int flags) {
-  parent=p;
+  DivPlatformYM2610Base::init(p, channels, sugRate, flags);
   dumpWrites=false;
   skipRegisterWrites=false;
   for (int i=0; i<16; i++) {
@@ -1255,8 +1255,6 @@ int DivPlatformYM2610B::init(DivEngine* p, int channels, int sugRate, unsigned i
   for (int i=0; i<16; i++) {
     oscBuf[i]->rate=rate;
   }
-  iface.parent=parent;
-  iface.sampleBank=0;
   fm=new ymfm::ym2610b(iface);
   // YM2149, 2MHz
   ay=new DivPlatformAY8910;
@@ -1273,6 +1271,7 @@ void DivPlatformYM2610B::quit() {
   ay->quit();
   delete ay;
   delete fm;
+  DivPlatformYM2610Base::quit();
 }
 
 DivPlatformYM2610B::~DivPlatformYM2610B() {

--- a/src/engine/platform/ym2610b.h
+++ b/src/engine/platform/ym2610b.h
@@ -26,7 +26,7 @@
 
 #include "ym2610.h"
 
-class DivPlatformYM2610B: public DivDispatch {
+class DivPlatformYM2610B: public DivPlatformYM2610Base {
   protected:
     const unsigned short chanOffs[6]={
       0x00, 0x01, 0x02, 0x100, 0x101, 0x102
@@ -85,7 +85,6 @@ class DivPlatformYM2610B: public DivDispatch {
     std::queue<QueuedWrite> writes;
     ymfm::ym2610b* fm;
     ymfm::ym2610b::output_data fmout;
-    DivYM2610Interface iface;
     unsigned char regPool[512];
     unsigned char lastBusy;
   

--- a/src/engine/vgmOps.cpp
+++ b/src/engine/vgmOps.cpp
@@ -713,10 +713,10 @@ SafeWriter* DivEngine::saveVGM(bool* sysToExport, bool loop, int version) {
   bool writeDACSamples=false;
   bool writeNESSamples=false;
   bool writePCESamples=false;
-  int writeADPCM=0;
+  DivDispatch* writeADPCM[2]={NULL,NULL};
   int writeSegaPCM=0;
-  int writeX1010=0;
-  int writeQSound=0;
+  DivDispatch* writeX1010[2]={NULL,NULL};
+  DivDispatch* writeQSound[2]={NULL,NULL};
 
   for (int i=0; i<song.systemLen; i++) {
     willExport[i]=false;
@@ -805,11 +805,11 @@ SafeWriter* DivEngine::saveVGM(bool* sysToExport, bool loop, int version) {
         if (!hasX1) {
           hasX1=disCont[i].dispatch->chipClock;
           willExport[i]=true;
-          writeX1010=1;
+          writeX1010[0]=disCont[i].dispatch;
         } else if (!(hasX1&0x40000000)) {
           isSecond[i]=true;
           willExport[i]=true;
-          writeX1010=2;
+          writeX1010[1]=disCont[i].dispatch;
           hasX1|=0x40000000;
           howManyChips++;
         }
@@ -823,11 +823,11 @@ SafeWriter* DivEngine::saveVGM(bool* sysToExport, bool loop, int version) {
         if (!hasOPNB) {
           hasOPNB=disCont[i].dispatch->chipClock;
           willExport[i]=true;
-          writeADPCM=1;
+          writeADPCM[0]=disCont[i].dispatch;
         } else if (!(hasOPNB&0x40000000)) {
           isSecond[i]=true;
           willExport[i]=true;
-          writeADPCM=2;
+          writeADPCM[1]=disCont[i].dispatch;
           hasOPNB|=0x40000000;
           howManyChips++;
         }
@@ -929,11 +929,11 @@ SafeWriter* DivEngine::saveVGM(bool* sysToExport, bool loop, int version) {
           // not be able to handle the 64kb sample bank trick
           hasQSound=disCont[i].dispatch->chipClock;
           willExport[i]=true;
-          writeQSound=1;
+          writeQSound[0]=disCont[i].dispatch;
         } else if (!(hasQSound&0x40000000)) {
           isSecond[i]=true;
           willExport[i]=false;
-          writeQSound=2;
+          writeQSound[1]=disCont[i].dispatch;
           addWarning("dual QSound is not supported by the VGM format");
         }
         break;
@@ -1249,56 +1249,55 @@ SafeWriter* DivEngine::saveVGM(bool* sysToExport, bool loop, int version) {
     delete[] pcmMem;
   }
 
-  if (adpcmAMemLen>0) {
-    for (int i=0; i<writeADPCM; i++) {
+  for (int i=0; i<2; i++) {
+    if (writeADPCM[i]!=NULL && writeADPCM[i]->getSampleMemUsage(0)>0) {
       w->writeC(0x67);
       w->writeC(0x66);
       w->writeC(0x82);
-      w->writeI((adpcmAMemLen+8)|(i*0x80000000));
-      w->writeI(adpcmAMemLen);
+      w->writeI((writeADPCM[i]->getSampleMemUsage(0)+8)|(i*0x80000000));
+      w->writeI(writeADPCM[i]->getSampleMemCapacity(0));
       w->writeI(0);
-      w->write(adpcmAMem,adpcmAMemLen);
+      w->write(writeADPCM[i]->getSampleMem(0),writeADPCM[i]->getSampleMemUsage(0));
     }
   }
 
-  if (adpcmBMemLen>0) {
-    for (int i=0; i<writeADPCM; i++) {
+  for (int i=0; i<2; i++) {
+    if (writeADPCM[i]!=NULL && writeADPCM[i]->getSampleMemUsage(1)>0) {
       w->writeC(0x67);
       w->writeC(0x66);
       w->writeC(0x83);
-      w->writeI((adpcmBMemLen+8)|(i*0x80000000));
-      w->writeI(adpcmBMemLen);
+      w->writeI((writeADPCM[i]->getSampleMemUsage(1)+8)|(i*0x80000000));
+      w->writeI(writeADPCM[i]->getSampleMemCapacity(1));
       w->writeI(0);
-      w->write(adpcmBMem,adpcmBMemLen);
+      w->write(writeADPCM[i]->getSampleMem(1),writeADPCM[i]->getSampleMemUsage(1));
     }
   }
 
-  if (qsoundMemLen>0) {
-    // always write a whole bank
-    unsigned int blockSize=(qsoundMemLen+0xffff)&(~0xffff);
-    if (blockSize > 0x1000000) {
-      blockSize = 0x1000000;
-    }
-    for (int i=0; i<writeQSound; i++) {
+  for (int i=0; i<2; i++) {
+    if (writeQSound[i]!=NULL && writeQSound[i]->getSampleMemUsage()>0) {
+      unsigned int blockSize=(writeQSound[i]->getSampleMemUsage()+0xffff)&(~0xffff);
+      if (blockSize > 0x1000000) {
+        blockSize = 0x1000000;
+      }
       w->writeC(0x67);
       w->writeC(0x66);
       w->writeC(0x8F);
       w->writeI((blockSize+8)|(i*0x80000000));
-      w->writeI(0x1000000);
+      w->writeI(writeQSound[i]->getSampleMemCapacity());
       w->writeI(0);
-      w->write(qsoundMem,blockSize);
+      w->write(writeQSound[i]->getSampleMem(),blockSize);
     }
   }
 
-  if (x1_010MemLen>0) {
-    for (int i=0; i<writeX1010; i++) {
+  for (int i=0; i<2; i++) {
+    if (writeX1010[i]!=NULL && writeX1010[i]->getSampleMemUsage()>0) {
       w->writeC(0x67);
       w->writeC(0x66);
       w->writeC(0x91);
-      w->writeI((x1_010MemLen+8)|(i*0x80000000));
-      w->writeI(x1_010MemLen);
+      w->writeI((writeX1010[i]->getSampleMemUsage()+8)|(i*0x80000000));
+      w->writeI(writeX1010[i]->getSampleMemCapacity());
       w->writeI(0);
-      w->write(x1_010Mem,x1_010MemLen);
+      w->write(writeX1010[i]->getSampleMem(),writeX1010[i]->getSampleMemUsage());
     }
   }
 

--- a/src/gui/stats.cpp
+++ b/src/gui/stats.cpp
@@ -28,22 +28,17 @@ void FurnaceGUI::drawStats() {
   }
   if (!statsOpen) return;
   if (ImGui::Begin("Statistics",&statsOpen)) {
-    String adpcmAUsage=fmt::sprintf("%d/16384KB",e->adpcmAMemLen/1024);
-    String adpcmBUsage=fmt::sprintf("%d/16384KB",e->adpcmBMemLen/1024);
-    String qsoundUsage=fmt::sprintf("%d/16384KB",e->qsoundMemLen/1024);
-    String x1_010Usage=fmt::sprintf("%d/1024KB",e->x1_010MemLen/1024);
-    ImGui::Text("ADPCM-A");
-    ImGui::SameLine();
-    ImGui::ProgressBar(((float)e->adpcmAMemLen)/16777216.0f,ImVec2(-FLT_MIN,0),adpcmAUsage.c_str());
-    ImGui::Text("ADPCM-B");
-    ImGui::SameLine();
-    ImGui::ProgressBar(((float)e->adpcmBMemLen)/16777216.0f,ImVec2(-FLT_MIN,0),adpcmBUsage.c_str());
-    ImGui::Text("QSound");
-    ImGui::SameLine();
-    ImGui::ProgressBar(((float)e->qsoundMemLen)/16777216.0f,ImVec2(-FLT_MIN,0),qsoundUsage.c_str());
-    ImGui::Text("X1-010");
-    ImGui::SameLine();
-    ImGui::ProgressBar(((float)e->x1_010MemLen)/1048576.0f,ImVec2(-FLT_MIN,0),x1_010Usage.c_str());
+    for (int i=0; i<e->song.systemLen; i++) {
+      DivDispatch* dispatch=e->getDispatch(i);
+      for (int j=0; dispatch!=NULL && dispatch->getSampleMemCapacity(j)>0; j++) {
+        size_t capacity=dispatch->getSampleMemCapacity(j);
+        size_t usage=dispatch->getSampleMemUsage(j);
+        String usageStr=fmt::sprintf("%d/%dKB",usage/1024,capacity/1024);
+        ImGui::Text("%s [%d]", e->getSystemName(e->song.system[i]), j);
+        ImGui::SameLine();
+        ImGui::ProgressBar(((float)usage)/((float)capacity),ImVec2(-FLT_MIN,0),usageStr.c_str());
+      }
+    }
   }
   if (ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows)) curWindow=GUI_WINDOW_STATS;
   ImGui::End();


### PR DESCRIPTION
To prevent rendering samples for systems that are not in use.

Additionally, it gives the systems more flexibility to render the samples
according to their specific configuration.