### PR TITLE
AY8930: Fix VGM output.

### DIFF
--- a/src/engine/platform/ay8930.cpp
+++ b/src/engine/platform/ay8930.cpp
@@ -25,7 +25,7 @@
 #include <math.h>
 
 #define rWrite(a,v) if (!skipRegisterWrites) {pendingWrites[a]=v;}
-#define immWrite(a,v) if (!skipRegisterWrites) {writes.emplace(a,v); if (dumpWrites) {addWrite(a,v);} }
+#define immWrite2(a,v) if (!skipRegisterWrites) {writes.emplace(a,v); if (dumpWrites) {addWrite(a,v);} }
 
 #define CHIP_DIVIDER 8
 
@@ -60,6 +60,18 @@ const char* regCheatSheetAY8930[]={
   "TEST", "1F",
   NULL
 };
+
+void DivPlatformAY8930::immWrite(unsigned char a, unsigned char v) {
+  if ((int)bank!=(a>>4)) {
+    bank=a>>4;
+    immWrite2(0x0d, 0xa0|(bank<<4)|ayEnvMode[0]);
+  }
+  if (a==0x0d) {
+    immWrite2(0x0d,0xa0|(bank<<4)|(v&15));
+  } else {
+    immWrite2(a&15,v);
+  }
+}
 
 const char** DivPlatformAY8930::getRegisterSheet() {
   return regCheatSheetAY8930;
@@ -123,18 +135,13 @@ void DivPlatformAY8930::acquire(short* bufL, short* bufR, size_t start, size_t l
   }
   while (!writes.empty()) {
     QueuedWrite w=writes.front();
-    if ((int)bank!=(w.addr>>4)) {
-      bank=w.addr>>4;
-      ay->address_w(0x0d);
-      ay->data_w(0xa0|(bank<<4)|ayEnvMode[0]);
-    }
-    ay->address_w(w.addr&15);
-    if (w.addr==0x0d) {
-      ay->data_w(0xa0|(bank<<4)|(w.val&15));
+    ay->address_w(w.addr);
+    ay->data_w(w.val);
+    if (w.addr!=0x0d && (regPool[0x0d]&0xf0)==0xb0) {
+      regPool[(w.addr&0x0f)|0x10]=w.val;
     } else {
-      ay->data_w(w.val);
+      regPool[w.addr&0x0f]=w.val;
     }
-    regPool[w.addr&0x1f]=w.val;
     writes.pop();
   }
   ay->sound_stream_update(ayBuf,len);

--- a/src/engine/platform/ay8930.h
+++ b/src/engine/platform/ay8930.h
@@ -73,6 +73,7 @@ class DivPlatformAY8930: public DivDispatch {
     size_t ayBufLen;
 
     void updateOutSel(bool immediate=false);
+    void immWrite(unsigned char a, unsigned char v);
 
     friend void putDispatchChan(void*,int,int);
   


### PR DESCRIPTION
It was outputting writes to (nonexistent) register addresses > 15.

Let me know if you want me to change anything. For example, I’m not a big fan of macros (esp. multi-line ones) so I made a function. But not sure if you agree.

I’m also working on a patch to fix the core to generate correct tone and noise periods, but I want to discuss it some more before submitting (and also make an extended test case) and I don’t have time for that today.