### PR TITLE
AY8930: Fix tone and noise period in expanded mode.

### DIFF
--- a/src/engine/platform/ay8930.cpp
+++ b/src/engine/platform/ay8930.cpp
@@ -27,7 +27,7 @@
 #define rWrite(a,v) if (!skipRegisterWrites) {pendingWrites[a]=v;}
 #define immWrite2(a,v) if (!skipRegisterWrites) {writes.emplace(a,v); if (dumpWrites) {addWrite(a,v);} }
 
-#define CHIP_DIVIDER 8
+#define CHIP_DIVIDER 4
 
 const char* regCheatSheetAY8930[]={
   "FreqL_A", "00",
@@ -645,7 +645,7 @@ void DivPlatformAY8930::setFlags(unsigned int flags) {
       chipClock=COLOR_NTSC/2.0;
       break;
   }
-  rate=chipClock/8;
+  rate=chipClock/4;
   for (int i=0; i<3; i++) {
     oscBuf[i]->rate=rate;
   }


### PR DESCRIPTION
The tone and noise periods generated in the VGM file do not match the AY8930 real hardware (tested with [Darky](https://www.msx.org/wiki/SuperSoniqs_Darky), MSX).

It turns out that in AY8930 extended mode the extra range of the tone periods does not just extend the range with four most significant bits, but actually extends the period range with three most significant bits and one least significant bit.

In other words, if you play a tone with a specific period in extended mode, it will sound one octave higher compared to compatibility mode. Note that this is [not documented](http://map.grauw.nl/resources/sound/microchip_ay8930.pdf) by Microchip. See the output of the test program below.

![ay8930-tgegperiod](https://user-images.githubusercontent.com/772052/166538154-29ed4894-2089-4f5a-8e64-67d7202f35e1.jpg)
[ay8930-tgegperiod.wav.zip](https://github.com/tildearrow/furnace/files/8613139/ay8930-tgegperiod.wav.zip)

This test shows that the tone period is shifted, but the envelope period is unaffected. Another test made with Furnace demonstrates that the noise period is also twice that of the current implementation:

[aytestex.zip](https://github.com/tildearrow/furnace/files/8613167/aytestex.zip)

This patch doubles the sample generation rate of the output to get full precision on the noise, and adjusts the period counter rates to match the real hardware.