### PR TITLE
put the cutoff in nes_fds.cpp back to 99999

### DIFF
--- a/src/engine/platform/sound/nes_nsfplay/nes_fds.cpp
+++ b/src/engine/platform/sound/nes_nsfplay/nes_fds.cpp
@@ -9,7 +9,7 @@ const int RC_BITS = 12;
 
 NES_FDS::NES_FDS ()
 {
-    option[OPT_CUTOFF] = 2000;
+    option[OPT_CUTOFF] = 99999;
     option[OPT_4085_RESET] = 0;
     option[OPT_WRITE_PROTECT] = 0; // not used here, see nsfplay.cpp
 


### PR DESCRIPTION
this is the best I could do fro now, I've looked all over for a volume level variable but most of the stuff I've poked around in the cpp file didn't have any effect on sound output, changing the cutoff variable was the only one I found that modified the sound output.