### PR TITLE
Add MSX Darky sound in preset

### DIFF
--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -426,6 +426,14 @@ void FurnaceGUI::initSystemPresets() {
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
+    "MSX + Darky", {
+      DIV_SYSTEM_AY8910, 64, 0, 16,
+      DIV_SYSTEM_AY8930, 64, 0, 0, // 3.58MHz(/2)
+      DIV_SYSTEM_AY8930, 64, 0, 0, // 3.58MHz(/2) or 3.6MHz, configurable via register
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (48K)", {
       DIV_SYSTEM_AY8910, 64, 0, 2,
       0


### PR DESCRIPTION
Supersoniq Darky is Sound expander for MSX, it has 2 AY8930 with configurable mixer per channel(soft panning, per-left/right output volume - not emulated) and programmable DSP for post processing(not emulated).
clock value is verified from manual but clock flag is placeholder, because clock select pin isn't still implemented for AY8930 in furnace.

<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->
