### PR TITLE
VERA: halve output volume to match other PSGs

### DIFF
--- a/src/engine/platform/vera.cpp
+++ b/src/engine/platform/vera.cpp
@@ -414,7 +414,7 @@ void DivPlatformVERA::muteChannel(int ch, bool mute) {
 }
 
 float DivPlatformVERA::getPostAmp() {
-  return 8.0f;
+  return 4.0f;
 }
 
 bool DivPlatformVERA::isStereo() {

--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -599,7 +599,7 @@ void FurnaceGUI::initSystemPresets() {
   cat.systems.push_back(FurnaceGUISysDef(
     "Commander X16", {
       DIV_SYSTEM_VERA, 64, 0, 0,
-      DIV_SYSTEM_YM2151, 64, 0, 0,
+      DIV_SYSTEM_YM2151, 32, 0, 0,
       0
     }
   ));


### PR DESCRIPTION
In terms of maximum single-channel output. X16's mixing is kept by halving YM2151 part.