### PR TITLE
Fix build errors related to std::fill, std::begin, and std::end

### DIFF
--- a/src/engine/platform/sound/n163/n163.hpp
+++ b/src/engine/platform/sound/n163/n163.hpp
@@ -7,6 +7,7 @@
 */
 
 #include <algorithm>
+#include <array>
 #include <memory>
 
 #ifndef _VGSOUND_EMU_N163_HPP
@@ -76,11 +77,11 @@ private:
 	};
 
 	bool m_disable = false;
-	u8 m_ram[0x80] = {0}; // internal 128 byte RAM
+	std::array<u8, 128> m_ram = {0}; // internal 128 byte RAM
 	u8 m_voice_cycle = 0x78; // Voice cycle for processing
 	addr_latch_t m_addr_latch; // address latch
 	s16 m_out = 0; // output
-  s16 m_ch_out[8] = {0}; // per channel output
+  std::array<s16, 8> m_ch_out = {0}; // per channel output
 	// demultiplex related
 	bool m_multiplex = true; // multiplex flag, but less noisy = inaccurate!
 	s16 m_acc = 0; // accumulated output

--- a/src/engine/platform/sound/scc/scc.hpp
+++ b/src/engine/platform/sound/scc/scc.hpp
@@ -9,6 +9,7 @@
 */
 
 #include <algorithm>
+#include <array>
 #include <memory>
 
 #ifndef _VGSOUND_EMU_SCC_HPP
@@ -114,7 +115,7 @@ protected:
 	test_t m_test;         // test register
 	s32 m_out = 0;         // output to DA0...10
 
-	u8 m_reg[256] = {0};   // register pool
+	std::array<u8, 256> m_reg = {0};   // register pool
 };
 
 // SCC core

--- a/src/engine/platform/sound/vrcvi/vrcvi.hpp
+++ b/src/engine/platform/sound/vrcvi/vrcvi.hpp
@@ -9,6 +9,7 @@
 */
 
 #include <algorithm>
+#include <array>
 #include <memory>
 
 #ifndef _VGSOUND_EMU_VRCVI_HPP
@@ -235,7 +236,7 @@ private:
 	vrcvi_intf &m_intf;
 
 	s8 m_out = 0; // 6 bit output
-  s8 m_ch_out[3] = {0}; // per-channel output
+  std::array<s8, 3> m_ch_out = {0}; // per-channel output
 };
 
 #endif


### PR DESCRIPTION
On some Linux-based systems (possibly others?) building fails due to multiple errors regarding using C-style arrays with `std::begin` and `std::end` (which are both passed to `std::fill`). This works around that by converting the affected arrays into `std::array`s which should be functionally identical.