### PR TITLE
$4011 temporarily disable

### DIFF
--- a/src/engine/platform/sound/nes_nsfplay/nes_dmc.cpp
+++ b/src/engine/platform/sound/nes_nsfplay/nes_dmc.cpp
@@ -46,7 +46,7 @@ namespace xgm
     SetClock (DEFAULT_CLOCK);
     SetRate (DEFAULT_RATE);
     SetPal (false);
-    option[OPT_ENABLE_4011] = 1;
+    option[OPT_ENABLE_4011] = 0;
     option[OPT_ENABLE_PNOISE] = 1;
     option[OPT_UNMUTE_ON_RESET] = 1;
     option[OPT_DPCM_ANTI_CLICK] = 0;


### PR DESCRIPTION
this will be reenabled again after tildearrow implements actual NES DPCM register writes, not just some $4011 abuse.

<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->
