### PR TITLE
More Y8950 ADPCM fixes

### DIFF
--- a/src/engine/platform/opl.cpp
+++ b/src/engine/platform/opl.cpp
@@ -735,6 +735,7 @@ int DivPlatformOPL::dispatch(DivCommand c) {
           if (chan[c.chan].sample>=0 && chan[c.chan].sample<parent->song.sampleLen) {
             DivSample* s=parent->getSample(chan[c.chan].sample);
             immWrite(8,0);
+            immWrite(7,0x01); // reset
             immWrite(9,(s->offB>>2)&0xff);
             immWrite(10,(s->offB>>10)&0xff);
             int end=s->offB+s->lengthB-1;
@@ -770,6 +771,7 @@ int DivPlatformOPL::dispatch(DivCommand c) {
           }
           DivSample* s=parent->getSample(12*sampleBank+c.value%12);
           immWrite(8,0);
+          immWrite(7,0x01); // reset
           immWrite(9,(s->offB>>2)&0xff);
           immWrite(10,(s->offB>>10)&0xff);
           int end=s->offB+s->lengthB-1;

--- a/src/engine/vgmOps.cpp
+++ b/src/engine/vgmOps.cpp
@@ -386,22 +386,22 @@ void DivEngine::performVGMWrite(SafeWriter* w, DivSystem sys, DivRegWrite& write
       case DIV_SYSTEM_Y8950_DRUMS:
         // disable envelope
         for (int i=0; i<6; i++) {
-          w->writeC(0x0b|baseAddr1);
+          w->writeC(0x0c|baseAddr1);
           w->writeC(0x80+i);
           w->writeC(0x0f);
-          w->writeC(0x0b|baseAddr1);
+          w->writeC(0x0c|baseAddr1);
           w->writeC(0x88+i);
           w->writeC(0x0f);
-          w->writeC(0x0b|baseAddr1);
+          w->writeC(0x0c|baseAddr1);
           w->writeC(0x90+i);
           w->writeC(0x0f);
         }
         // key off + freq reset
         for (int i=0; i<9; i++) {
-          w->writeC(0x0b|baseAddr1);
+          w->writeC(0x0c|baseAddr1);
           w->writeC(0xa0+i);
           w->writeC(0);
-          w->writeC(0x0b|baseAddr1);
+          w->writeC(0x0c|baseAddr1);
           w->writeC(0xb0+i);
           w->writeC(0);
         }


### PR DESCRIPTION
Fixes playback on real hardware, and a few other things.

1. Send soft chip reset commands to the correct VGM chip ID. 
2. Stop & reset the ADPCM before starting new sample, otherwise it doesn’t play right. Emulation does not match reality.
3. ~~Reduce the padding to the minimum of 4 byte alignment.~~
    * ~~Also remove that `+256` when setting `adpcmBMemLen`. Seems like it should be removed elsewhere too, `memPos` is already correctly padded, increasing it further can cause overflow beyond max memory size?~~
4. ~~Remove a check for crossing the 1M threshold which I presume only applied to YM2610.~~
    * ~~Reminds me of the bank bits in the Y8950’s ADPCM ROM mode btw.~~