### PR TITLE
Fix multithreading on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,13 +93,9 @@ jobs:
       id: build-cores
       run: |
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        set amount=2
+        amount=2
         if [ '${{ runner.os }}' == 'macOS' ]; then
           amount=3
-        fi
-        # the Actions runner does not seem to be happy with two jobs at once on MinGW/Ubuntu
-        if [ '${{ runner.os }}' == 'Linux' ]; then
-          amount=1
         fi
 
         echo "Amount of cores we can build with: ${amount}"


### PR DESCRIPTION
`set` is not the right command to set an envvar so "" got propagated to --parallel & in turn -j.
"-j" (no job count) is _bad_ and prolly caused the OOM sitations.

Example of a `cmake --build ... --parallel` / `make -j` run on my system.

![Bildschirmfoto von 2022-05-26 11-47-39](https://user-images.githubusercontent.com/23431373/170463934-961eeede-1d3a-45a0-bcc2-b5d278b69de4.png)

