### PR TITLE
Small Fractal fixes

### DIFF
--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -104,13 +104,13 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "Yamaha YM2612 (OPN2) with DualPCM", {
-      DIV_SYSTEM_YM2612, 64, 0, (int)0x80000000,
+      DIV_SYSTEM_YM2612_FRAC, 64, 0, (int)0x80000000,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "Yamaha YM2612 (extended channel 3) with DualPCM", {
-      DIV_SYSTEM_YM2612_EXT, 64, 0, (int)0x80000000,
+      DIV_SYSTEM_YM2612_FRAC_EXT, 64, 0, (int)0x80000000,
       0
     }
   ));

--- a/src/gui/sysConf.cpp
+++ b/src/gui/sysConf.cpp
@@ -25,7 +25,9 @@ void FurnaceGUI::drawSysConf(int chan, DivSystem type, unsigned int& flags, bool
   unsigned int copyOfFlags=flags;
   switch (type) {
     case DIV_SYSTEM_YM2612:
-    case DIV_SYSTEM_YM2612_EXT: {
+    case DIV_SYSTEM_YM2612_EXT: 
+    case DIV_SYSTEM_YM2612_FRAC:
+    case DIV_SYSTEM_YM2612_FRAC_EXT: {
       if (ImGui::RadioButton("NTSC (7.67MHz)",(flags&7)==0)) {
         copyOfFlags=(flags&0x80000000)|0;
       }


### PR DESCRIPTION
Fixed YM2612 flags not appearing in any Fractal preset and the YM2612-specific DualPCM presets putting in a standard YM2612.