### PR TITLE
Implement Phase Reset Timer macro for Sound Unit

### DIFF
--- a/src/engine/platform/su.cpp
+++ b/src/engine/platform/su.cpp
@@ -187,6 +187,13 @@ void DivPlatformSoundUnit::tick(bool sysTick) {
       chan[i].control=chan[i].std.ex3.val&15;
       writeControl(i);
     }
+    if (chan[i].std.ex4.had) {
+      chan[i].syncTimer=chan[i].std.ex4.val&65535;
+      chan[i].timerSync=(chan[i].syncTimer>0);
+      chWrite(i,0x1e,chan[i].syncTimer&0xff);
+      chWrite(i,0x1f,chan[i].syncTimer>>8);
+      writeControlUpper(i);
+    }
     if (chan[i].freqChanged || chan[i].keyOn || chan[i].keyOff) {
       //DivInstrument* ins=parent->getIns(chan[i].ins,DIV_INS_SU);
       chan[i].freq=parent->calcFreq(chan[i].baseFreq,chan[i].pitch,false,2,chan[i].pitch2,chipClock,CHIP_FREQBASE);

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -3512,6 +3512,7 @@ void FurnaceGUI::drawInsEdit() {
 
           int ex1Max=(ins->type==DIV_INS_AY8930)?8:0;
           int ex2Max=(ins->type==DIV_INS_AY || ins->type==DIV_INS_AY8930)?4:0;
+          int ex4Max=(ins->type==DIV_INS_AY || ins->type==DIV_INS_AY8930)?4:0; // i am too lazy to figure out what this does so copy and paste ex2Max
           bool ex2Bit=true;
 
           if (ins->type==DIV_INS_C64) {
@@ -3677,6 +3678,7 @@ void FurnaceGUI::drawInsEdit() {
           }
           if (ins->type==DIV_INS_SU) {
             macroList.push_back(FurnaceGUIMacroDesc("Control",&ins->std.ex3Macro,0,4,64,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true,suControlBits));
+            macroList.push_back(FurnaceGUIMacroDesc("Phase Reset Timer",&ins->std.ex4Macro,0,ex4Max,160,uiColors[GUI_COLOR_MACRO_OTHER])); // again reuse code from resonance macro but use ex4 instead
           }
 
           drawMacros(macroList);

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -3512,7 +3512,6 @@ void FurnaceGUI::drawInsEdit() {
 
           int ex1Max=(ins->type==DIV_INS_AY8930)?8:0;
           int ex2Max=(ins->type==DIV_INS_AY || ins->type==DIV_INS_AY8930)?4:0;
-          int ex4Max=(ins->type==DIV_INS_AY || ins->type==DIV_INS_AY8930)?4:0; // i am too lazy to figure out what this does so copy and paste ex2Max
           bool ex2Bit=true;
 
           if (ins->type==DIV_INS_C64) {
@@ -3678,7 +3677,7 @@ void FurnaceGUI::drawInsEdit() {
           }
           if (ins->type==DIV_INS_SU) {
             macroList.push_back(FurnaceGUIMacroDesc("Control",&ins->std.ex3Macro,0,4,64,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true,suControlBits));
-            macroList.push_back(FurnaceGUIMacroDesc("Phase Reset Timer",&ins->std.ex4Macro,0,ex4Max,160,uiColors[GUI_COLOR_MACRO_OTHER])); // again reuse code from resonance macro but use ex4 instead
+            macroList.push_back(FurnaceGUIMacroDesc("Phase Reset Timer",&ins->std.ex4Macro,0,65535,160,uiColors[GUI_COLOR_MACRO_OTHER])); // again reuse code from resonance macro but use ex4 instead
           }
 
           drawMacros(macroList);


### PR DESCRIPTION
<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->
This new macro allows the user to set the value of the phase reset timer in the TildeArrow Sound Unit in instruments without relying on effects.