### PR TITLE
Haiku support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,13 @@ if (NOT WIN32 AND NOT APPLE)
   endif()
 endif()
 
+if (NOT WIN32)
+  try_compile(HAVE_DIRENT_TYPE ${CMAKE_BINARY_DIR}/check SOURCES ${CMAKE_SOURCE_DIR}/src/check/check_dirent_type.c)
+  if (HAVE_DIRENT_TYPE)
+    list(APPEND DEPENDENCIES_DEFINES HAVE_DIRENT_TYPE)
+  endif()
+endif()
+
 set(USED_SOURCES ${ENGINE_SOURCES} ${AUDIO_SOURCES} src/main.cpp)
 
 if (USE_BACKWARD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,10 +698,9 @@ if (PKG_CONFIG_FOUND AND (SYSTEM_FMT OR SYSTEM_LIBSNDFILE OR SYSTEM_ZLIB OR SYST
 endif()
 
 if (NOT ANDROID OR TERMUX)
-  install(TARGETS furnace RUNTIME DESTINATION bin)
-  
   if (NOT WIN32 AND NOT APPLE)
     include(GNUInstallDirs)
+    install(TARGETS furnace RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES res/furnace.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
     install(FILES res/furnace.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
     install(DIRECTORY papers DESTINATION ${CMAKE_INSTALL_DOCDIR})
@@ -714,8 +713,10 @@ if (NOT ANDROID OR TERMUX)
       install(FILES res/icon.iconset/icon_${res}@2x.png RENAME furnace.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/${res}@2/apps)
     endforeach()
     install(FILES res/logo.png RENAME furnace.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/1024x1024/apps)
+  else()
+    install(TARGETS furnace RUNTIME DESTINATION bin)
   endif()
-  
+
   set(CPACK_PACKAGE_NAME "Furnace")
   set(CPACK_PACKAGE_VENDOR "tildearrow")
   set(CPACK_PACKAGE_DESCRIPTION "free and open-source chiptune tracker")

--- a/extern/igfd/ImGuiFileDialog.cpp
+++ b/extern/igfd/ImGuiFileDialog.cpp
@@ -1549,7 +1549,7 @@ namespace IGFD
 					struct dirent* ent = files[i];
 					std::string where = path + std::string("/") + std::string(ent->d_name);
 					char fileType = 0;
-#  ifdef HAVE_DIRENT_TYPE
+#ifdef HAVE_DIRENT_TYPE
 					if (ent->d_type != DT_UNKNOWN)
 					{
 						switch (ent->d_type)
@@ -1580,7 +1580,7 @@ namespace IGFD
 						}
 					}
 					else
-#  endif // HAVE_DIRENT_TYPE
+#endif // HAVE_DIRENT_TYPE
 					{
 						struct stat filestat;
 						if (stat(where.c_str(), &filestat) == 0)

--- a/src/check/check_dirent_type.c
+++ b/src/check/check_dirent_type.c
@@ -1,0 +1,7 @@
+#include <dirent.h>
+
+int main(int, char**) {
+  struct dirent deTest = { };
+  unsigned char deType = deTest.d_type;
+  return 0;
+}

--- a/src/engine/config.cpp
+++ b/src/engine/config.cpp
@@ -43,7 +43,7 @@ void DivEngine::initConfDir() {
 #elif defined (IS_MOBILE)
   configPath=SDL_GetPrefPath();
 #else
-#  ifdef __HAIKU__
+#ifdef __HAIKU__
   char userSettingsDir[PATH_MAX];
   status_t findUserDir = find_directory(B_USER_SETTINGS_DIRECTORY,0,true,userSettingsDir,PATH_MAX);
   if (findUserDir==B_OK) {
@@ -53,7 +53,7 @@ void DivEngine::initConfDir() {
     configPath=".";
     return;
   }
-#  else
+#else
   // TODO this should check XDG_CONFIG_HOME first
   char* home=getenv("HOME");
   if (home==NULL) {
@@ -69,18 +69,18 @@ void DivEngine::initConfDir() {
   } else {
     configPath=home;
   }
-#    ifdef __APPLE__
+#ifdef __APPLE__
   configPath+="/Library/Application Support";
-#    else
+#else
   // FIXME this doesn't honour XDG_CONFIG_HOME *at all*
   configPath+="/.config";
-#    endif
-#  endif
-#  ifdef __APPLE__
+#endif // __APPLE__
+#endif // __HAIKU__
+#ifdef __APPLE__
   configPath+="/Furnace";
-#  else
+#else
   configPath+="/furnace";
-#  endif
+#endif // __APPLE__
   struct stat st;
   std::string pathSep="/";
   configPath+=pathSep;
@@ -98,7 +98,7 @@ void DivEngine::initConfDir() {
     sepPos=configPath.find(pathSep,sepPos);
   }
   configPath.resize(configPath.length()-pathSep.length());
-#endif
+#endif // _WIN32
 }
 
 bool DivEngine::saveConf() {

--- a/src/engine/config.cpp
+++ b/src/engine/config.cpp
@@ -66,11 +66,10 @@ void DivEngine::initConfDir() {
   size_t sepPos=configPath.find(pathSep,1);
   while (sepPos!=std::string::npos) {
     std::string subpath=configPath.substr(0,sepPos++);
-    logI("checking config path component %s ...",subpath.c_str());
     if (stat(subpath.c_str(),&st)!=0) {
-      logI("creating config path component %s ...",subpath.c_str());
+      logI("creating config path element %s ...",subpath.c_str());
       if (mkdir(subpath.c_str(),0755)!=0) {
-        logW("could not create config path component %s! (%s)",subpath.c_str(),strerror(errno));
+        logW("could not create config path element %s! (%s)",subpath.c_str(),strerror(errno));
         configPath=".";
         return;
       }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -27,11 +27,6 @@
 #include "../audio/sdlAudio.h"
 #endif
 #include <stdexcept>
-#ifndef _WIN32
-#include <unistd.h>
-#include <pwd.h>
-#include <sys/stat.h>
-#endif
 #ifdef HAVE_JACK
 #include "../audio/jack.h"
 #endif
@@ -2983,36 +2978,6 @@ void DivEngine::quitDispatch() {
   BUSY_END;
 }
 
-#define CHECK_CONFIG_DIR_MAC() \
-  configPath+="/Library/Application Support/Furnace"; \
-  if (stat(configPath.c_str(),&st)<0) { \
-    logI("creating config dir..."); \
-    if (mkdir(configPath.c_str(),0755)<0) { \
-      logW("could not make config dir! (%s)",strerror(errno)); \
-      configPath="."; \
-    } \
-  }
-
-#define CHECK_CONFIG_DIR() \
-  configPath+="/.config"; \
-  if (stat(configPath.c_str(),&st)<0) { \
-    logI("creating user config dir..."); \
-    if (mkdir(configPath.c_str(),0755)<0) { \
-      logW("could not make user config dir! (%s)",strerror(errno)); \
-      configPath="."; \
-    } \
-  } \
-  if (configPath!=".") { \
-    configPath+="/furnace"; \
-    if (stat(configPath.c_str(),&st)<0) { \
-      logI("creating config dir..."); \
-      if (mkdir(configPath.c_str(),0755)<0) { \
-        logW("could not make config dir! (%s)",strerror(errno)); \
-        configPath="."; \
-      } \
-    } \
-  }
-
 bool DivEngine::initAudioBackend() {
   // load values
   if (audioEngine==DIV_AUDIO_NULL) {
@@ -3142,45 +3107,12 @@ bool DivEngine::deinitAudioBackend() {
   return true;
 }
 
-#ifdef _WIN32
-#include "winStuff.h"
-#endif
-
 bool DivEngine::init() {
   // register systems
   if (!systemsRegistered) registerSystems();
-  
+
   // init config
-#ifdef _WIN32
-  configPath=getWinConfigPath();
-#elif defined(IS_MOBILE)
-  configPath=SDL_GetPrefPath("tildearrow","furnace");
-#else
-  struct stat st;
-  char* home=getenv("HOME");
-  if (home==NULL) {
-    int uid=getuid();
-    struct passwd* entry=getpwuid(uid);
-    if (entry==NULL) {
-      logW("unable to determine config directory! (%s)",strerror(errno));
-      configPath=".";
-    } else {
-      configPath=entry->pw_dir;
-#ifdef __APPLE__
-      CHECK_CONFIG_DIR_MAC();
-#else
-      CHECK_CONFIG_DIR();
-#endif
-    }
-  } else {
-    configPath=home;
-#ifdef __APPLE__
-    CHECK_CONFIG_DIR_MAC();
-#else
-    CHECK_CONFIG_DIR();
-#endif
-  }
-#endif
+  initConfDir();
   logD("config path: %s",configPath.c_str());
 
   loadConf();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -484,7 +484,7 @@ class DivEngine {
     // returns the minimum VGM version which may carry the specified system, or 0 if none.
     int minVGMVersion(DivSystem which);
 
-    // determine & setup config dir
+    // determine and setup config dir
     void initConfDir();
 
     // save config

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -484,6 +484,9 @@ class DivEngine {
     // returns the minimum VGM version which may carry the specified system, or 0 if none.
     int minVGMVersion(DivSystem which);
 
+    // determine & setup config dir
+    void initConfDir();
+
     // save config
     bool saveConf();
 

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -39,6 +39,13 @@
 #define POWER_SAVE_DEFAULT 0
 #endif
 
+#ifdef __HAIKU__
+// NFD doesn't support Haiku
+#define SYS_FILE_DIALOG_DEFAULT 0
+#else
+#define SYS_FILE_DIALOG_DEFAULT 1
+#endif
+
 const char* mainFonts[]={
   "IBM Plex Sans",
   "Liberation Sans",
@@ -2016,7 +2023,7 @@ void FurnaceGUI::syncSettings() {
   settings.insFocusesPattern=e->getConfInt("insFocusesPattern",1);
   settings.stepOnInsert=e->getConfInt("stepOnInsert",0);
   settings.unifiedDataView=e->getConfInt("unifiedDataView",0);
-  settings.sysFileDialog=e->getConfInt("sysFileDialog",1);
+  settings.sysFileDialog=e->getConfInt("sysFileDialog",SYS_FILE_DIALOG_DEFAULT);
   settings.roundedWindows=e->getConfInt("roundedWindows",1);
   settings.roundedButtons=e->getConfInt("roundedButtons",1);
   settings.roundedMenus=e->getConfInt("roundedMenus",0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,7 @@ int main(int argc, char** argv) {
     logE("CoInitializeEx failed!");
   }
 #endif
-#if !(defined(__APPLE__) || defined(_WIN32) || defined(ANDROID))
+#if !(defined(__APPLE__) || defined(_WIN32) || defined(ANDROID) || defined(__HAIKU__))
   // workaround for Wayland HiDPI issue
   if (getenv("SDL_VIDEODRIVER")==NULL) {
     setenv("SDL_VIDEODRIVER","x11",1);


### PR DESCRIPTION
Closes #590

CC @Begasus from https://github.com/tildearrow/furnace/issues/464#issuecomment-1173592592

VM
![image](https://user-images.githubusercontent.com/23431373/180018564-e823ce62-6332-466b-a6f6-3c0b0a2b4c19.png)

Spare hardware
![IMG_20220720_172015](https://user-images.githubusercontent.com/23431373/180020460-a64b8b55-6bdb-4f57-97de-3e2c98a161fc.jpg)

Performance is not great because it renders with llvmpipe but it works.

---

First commit is no-brainer, forcing X11 video driver on Haiku won't work. :stuck_out_tongue:

~~Second commit is WIP. IGFD uses [`dirent.d_type` which isn't POSIX-defined](https://www.man7.org/linux/man-pages/man0/dirent.h.0p.html) and Haiku doesn't implement it. [`stat`](https://www.man7.org/linux/man-pages/man3/fstatat.3p.html) should offer a `st_mode` field and there are seemingly POSIX-defined [ways of detecting various types of files](https://www.gnu.org/software/libc/manual/html_node/Testing-File-Type.html) based on that but I haven't messed with this yet. Submission is much dumber but works in the short-term to get it to build and to argue about how to solve this: Should I just rip that whole block out and try to replace it with `stat` and type checks or do you prefer the current way of checking things, for those targets that support it?~~

See comments from Haiku maintainers about what all the following commits are for.