### PR TITLE
Fix OPM load bug relating to AM-ENA values above 1

### DIFF
--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -21,6 +21,7 @@
 #include "../ta-log.h"
 #include "../fileutils.h"
 #include <fmt/printf.h>
+#include <stdint.h>
 
 enum DivInsFormats {
   DIV_INSFORMAT_DMP,

--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -21,7 +21,7 @@
 #include "../ta-log.h"
 #include "../fileutils.h"
 #include <fmt/printf.h>
-#include <stdint.h>
+#include <limits.h>
 
 enum DivInsFormats {
   DIV_INSFORMAT_DMP,

--- a/src/engine/fileOpsIns.cpp
+++ b/src/engine/fileOpsIns.cpp
@@ -1262,7 +1262,7 @@ void DivEngine::loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, St
     patchNameRead = lfoRead = characteristicRead = m1Read = c1Read = m2Read = c2Read = false;
     newPatch = NULL;
   };
-  auto readIntStrWithinRange = [](String&& input, int limitLow, int limitHigh) -> int {
+  auto readIntStrWithinRange = [](String&& input, int limitLow = INT_MIN, int limitHigh = INT_MAX) -> int {
     int x = std::stoi(input.c_str());
     if (x > limitHigh || x < limitLow) {
       throw std::invalid_argument(fmt::sprintf("%s is out of bounds of range [%d..%d]", input, limitLow, limitHigh));
@@ -1280,7 +1280,7 @@ void DivEngine::loadOPM(SafeReader& reader, std::vector<DivInstrument*>& ret, St
     op.mult = readIntStrWithinRange(reader.readStringToken(), 0, 15);
     op.dt = fmDtRegisterToFurnace(readIntStrWithinRange(reader.readStringToken(), 0, 7));
     op.dt2 = readIntStrWithinRange(reader.readStringToken(), 0, 3);
-    op.am = readIntStrWithinRange(reader.readStringToken(), 0, 1);
+    op.am = readIntStrWithinRange(reader.readStringToken(), 0) > 0 ? 1 : 0;
   };
   auto seekGroupValStart = [](SafeReader& reader, int pos) {
     // Seek to position then move to next ':' character


### PR DESCRIPTION
It appears some OPM file generators/conversion tools set the AME / AM-ENA register columns as 0 or 128 as opposed to 0 or 1.
This quick fix removes the upper range restriction and treats non-zero as enabled, 0 = disabled.