### PR TITLE
fix n163 doc

### DIFF
--- a/papers/doc/7-systems/dac.md
+++ b/papers/doc/7-systems/dac.md
@@ -1,0 +1,7 @@
+# Generic PCM DAC
+
+Realtek HD Audio's predecessor. It's just a 1/8/16-bit sample channel, with freely selectable rate and mono/stereo settings. With it, you can emulate PCM DACs found in Williams arcade boards, Sound Blasters, MSX TurboR, Atari STE, NEC PC-9801-86 etc.
+
+# effects
+
+none yet.

--- a/papers/doc/7-systems/mmc5.md
+++ b/papers/doc/7-systems/mmc5.md
@@ -9,4 +9,4 @@ additionally, it offers an 8-bit DAC which can be used to play samples. only one
 # effects
 
 - `12xx`: set duty cycle or noise mode of channel.
-  - may be 0-3 for the pulse channels and 0-1 for the noise channel.
+  - may be 0-3 for the pulse channels

--- a/papers/doc/7-systems/mmc5.md
+++ b/papers/doc/7-systems/mmc5.md
@@ -9,4 +9,4 @@ additionally, it offers an 8-bit DAC which can be used to play samples. only one
 # effects
 
 - `12xx`: set duty cycle or noise mode of channel.
-  - may be 0-3 for the pulse channels
+  - may be 0-3 for the pulse channels.

--- a/papers/doc/7-systems/n163.md
+++ b/papers/doc/7-systems/n163.md
@@ -1,8 +1,8 @@
 # Namco 163 (also called N163, Namco C163, Namco 106 (sic), Namco 160 or Namco 129)
 
-This is one of Namco's NES mappers, with up to 8 wavetable channels. It has also 256 nibbles (128 bytes) of internal RAM, and both channel registers and wavetables are stored here. Wavetables are variable in size and freely allocable anywhere in RAM, it means it can use part of or continuously pre-loaded waveform and its sequences in RAM. At least 64 bytes can dedicated to waves, with more available if not all channels are used - waveform RAM area becomes smaller as more channels are activated, since channel registers consume 8 bytes for each channel. You must avoid conflict with channel register area and waveform to avoid broken channel playback.
+This is one of Namco's NES mappers, with up to 8 wavetable channels. It has also 256 nibbles (128 bytes) of internal RAM, and both channel registers and wavetables are stored here. Wavetables are variable in size and freely allocable anywhere in RAM, it means it can use part of or continuously pre-loaded waveform and its sequences in RAM. At least 128 nibbles (64 bytes) can be dedicated to waves, with more available if not all channels are used - waveform RAM area becomes smaller as more channels are activated, since channel registers consume 8 bytes for each channel. You must avoid conflict with channel register area and waveform to avoid broken channel playback.
 
-Namco 163 does not internally mix its channels. Instead, each channel is output one at a time, when multiple channels are used it will cycle between them; so its sound quality gets more crunchy as more channels are activated.
+Namco 163 does not internally mix its channels. Because of that, only one channel can be output at the time, when multiple channels are used it will cycle between them, similarily to OPLL. Therefore, its sound quality gets more crunchy as more channels are activated.
 
 Furnace supports loading waveforms into RAM and waveform playback simultaneously, and channel limit is dynamically changeable with effect commands.
 You must load waveform to RAM first for playback, as its load behavior auto-updates when every waveform changes.

--- a/papers/doc/7-systems/n163.md
+++ b/papers/doc/7-systems/n163.md
@@ -1,6 +1,6 @@
 # Namco 163 (also called N163, Namco C163, Namco 106 (sic), Namco 160 or Namco 129)
 
-This is one of Namco's NES mappers, with up to 8 wavetable channels. It has also 128 byte of internal RAM, and both channel register and wavetables are stored here. Wavetables are variable size and freely allocable anywhere in RAM, it means it can use part of or continuously pre-loaded waveform and its sequences in RAM. But waveform RAM area becomes smaller as more channels are activated; as channel registers consumes 8 bytes for each channel. You must avoid conflict with channel register area and waveform for avoid broken channel playback.
+This is one of Namco's NES mappers, with up to 8 wavetable channels. It has also 256 bytes of internal RAM, and both channel register and wavetables are stored here. Wavetables are variable in size and freely allocable anywhere in RAM, it means it can use part of or continuously pre-loaded waveform and its sequences in RAM. But waveform RAM area becomes smaller as more channels are activated; as channel registers consume 8 bytes for each channel. You must avoid conflict with channel register area and waveform to avoid broken channel playback.
 
 It outputs only a single channel at clock; so its sound quality gets more crunchy as more channels are activated.
 

--- a/papers/doc/7-systems/n163.md
+++ b/papers/doc/7-systems/n163.md
@@ -1,8 +1,8 @@
 # Namco 163 (also called N163, Namco C163, Namco 106 (sic), Namco 160 or Namco 129)
 
-This is one of Namco's NES mappers, with up to 8 wavetable channels. It has also 256 bytes of internal RAM, and both channel register and wavetables are stored here. Wavetables are variable in size and freely allocable anywhere in RAM, it means it can use part of or continuously pre-loaded waveform and its sequences in RAM. But waveform RAM area becomes smaller as more channels are activated; as channel registers consume 8 bytes for each channel. You must avoid conflict with channel register area and waveform to avoid broken channel playback.
+This is one of Namco's NES mappers, with up to 8 wavetable channels. It has also 256 nibbles (128 bytes) of internal RAM, and both channel registers and wavetables are stored here. Wavetables are variable in size and freely allocable anywhere in RAM, it means it can use part of or continuously pre-loaded waveform and its sequences in RAM. At least 64 bytes can dedicated to waves, with more available if not all channels are used - waveform RAM area becomes smaller as more channels are activated, since channel registers consume 8 bytes for each channel. You must avoid conflict with channel register area and waveform to avoid broken channel playback.
 
-It outputs only a single channel at clock; so its sound quality gets more crunchy as more channels are activated.
+Namco 163 does not internally mix its channels. Instead, each channel is output one at a time, when multiple channels are used it will cycle between them; so its sound quality gets more crunchy as more channels are activated.
 
 Furnace supports loading waveforms into RAM and waveform playback simultaneously, and channel limit is dynamically changeable with effect commands.
 You must load waveform to RAM first for playback, as its load behavior auto-updates when every waveform changes.


### PR DESCRIPTION
256 bytes, not 128. https://www.nesdev.org/wiki/Namco_163_audio

also some better wording

