### PR TITLE
Fix the difference of volume slide behaviour related to previous volume

### DIFF
--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -533,13 +533,21 @@ void DivEngine::processRow(int i, bool afterDelay) {
 
   // volume
   if (pat->data[whatRow][3]!=-1) {
+    int cond=0;
     if (dispatchCmd(DivCommand(DIV_ALWAYS_SET_VOLUME,i)) || (MIN(chan[i].volMax,chan[i].volume)>>8)!=pat->data[whatRow][3]) {
-      if (pat->data[whatRow][0]==0 && pat->data[whatRow][1]==0) {
-        chan[i].midiAftertouch=true;
-      }
+      cond=3;
+    } else if (MIN(chan[i].volMax,chan[i].volume)!=(pat->data[whatRow][3]<<8)) {
+      cond=1;
+    }
+    if (cond) {
       chan[i].volume=pat->data[whatRow][3]<<8;
-      dispatchCmd(DivCommand(DIV_CMD_VOLUME,i,chan[i].volume>>8));
-      dispatchCmd(DivCommand(DIV_CMD_HINT_VOLUME,i,chan[i].volume>>8));
+      if (cond&2) {
+        if (pat->data[whatRow][0]==0 && pat->data[whatRow][1]==0) {
+          chan[i].midiAftertouch=true;
+        }
+        dispatchCmd(DivCommand(DIV_CMD_VOLUME,i,chan[i].volume>>8));
+        dispatchCmd(DivCommand(DIV_CMD_HINT_VOLUME,i,chan[i].volume>>8));
+      }
     }
   }
 


### PR DESCRIPTION
<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->

[volumeslide.zip](https://github.com/tildearrow/furnace/files/9809116/volumeslide.zip) - This is OPN song, so the max volume of PSG is 15.

![image](https://user-images.githubusercontent.com/26477882/196398980-47e31cc5-0a1a-4916-85b8-c0289c0f996c.png)

These two note slides behave differently. I explain this in playback.cpp before changes:

- 1st row: chan[i].volume=0xFFF at the beginning. The condition at L536 is false, so the volume slide is executed from chan[i].volume=0xFFF. Therefore, the actual PSG volume on the first tick is 0xF.
- 4th row: chan[i].volume=0x000 at the beginning. The condition at L536 is true, so chan[i].volume is changed to 0xF00 at L540  before the volume slide is executed. Therefore, the actual PSG volume on the first tick is 0xE.

This PR fixes the behavior of 1st row to be the same as 4 th row: When chan[i].volume>>8 is the same as the volume value on the pattern, chan[i].volume should be updated even if DivCommand is not sent.
