### PR TITLE
Regroup multi-chip presets / fix preset detection

### DIFF
--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -834,512 +834,6 @@ void FurnaceGUI::initSystemPresets() {
   ));
   sysCategories.push_back(cat);
 
-  cat=FurnaceGUISysCategory("FM","chips which use frequency modulation (FM) to generate sound.\nsome of these also pack more (like square and sample channels).");
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2151 (OPM)", {
-      DIV_SYSTEM_YM2151, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2203 (OPN)", {
-      DIV_SYSTEM_OPN, 64, 0, 3,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2203 (extended channel 3)", {
-      DIV_SYSTEM_OPN_EXT, 64, 0, 3,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2608 (OPNA)", {
-      DIV_SYSTEM_PC98, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2608 (extended channel 3)", {
-      DIV_SYSTEM_PC98_EXT, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2610 (OPNB)", {
-      DIV_SYSTEM_YM2610_FULL, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2610 (extended channel 2)", {
-      DIV_SYSTEM_YM2610_FULL_EXT, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2610B (OPNB2)", {
-      DIV_SYSTEM_YM2610B, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2610B (extended channel 3)", {
-      DIV_SYSTEM_YM2610B_EXT, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2612 (OPN2)", {
-      DIV_SYSTEM_YM2612, 64, 0, (int)0x80000000,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2612 (extended channel 3)", {
-      DIV_SYSTEM_YM2612_EXT, 64, 0, (int)0x80000000,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2612 (OPN2) with DualPCM", {
-      DIV_SYSTEM_YM2612_FRAC, 64, 0, (int)0x80000000,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2612 (extended channel 3) with DualPCM", {
-      DIV_SYSTEM_YM2612_FRAC_EXT, 64, 0, (int)0x80000000,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2413 (OPLL)", {
-      DIV_SYSTEM_OPLL, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2413 (drums mode)", {
-      DIV_SYSTEM_OPLL_DRUMS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2414 (OPZ)", {
-      DIV_SYSTEM_OPZ, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3438 (OPN2C)", {
-      DIV_SYSTEM_YM2612, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3438 (extended channel 3)", {
-      DIV_SYSTEM_YM2612_EXT, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3438 (OPN2C) with DualPCM", {
-      DIV_SYSTEM_YM2612_FRAC, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3438 (extended channel 3) with DualPCM", {
-      DIV_SYSTEM_YM2612_FRAC_EXT, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3526 (OPL)", {
-      DIV_SYSTEM_OPL, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3526 (drums mode)", {
-      DIV_SYSTEM_OPL_DRUMS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha Y8950", {
-      DIV_SYSTEM_Y8950, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha Y8950 (drums mode)", {
-      DIV_SYSTEM_Y8950_DRUMS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3812 (OPL2)", {
-      DIV_SYSTEM_OPL2, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM3812 (drums mode)", {
-      DIV_SYSTEM_OPL2_DRUMS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YMF262 (OPL3)", {
-      DIV_SYSTEM_OPL3, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YMF262 (drums mode)", {
-      DIV_SYSTEM_OPL3_DRUMS, 64, 0, 0,
-      0
-    }
-  ));
-  if (settings.hiddenSystems) {
-    cat.systems.push_back(FurnaceGUISysDef(
-      "Yamaha YMU759 (MA-2)", {
-        DIV_SYSTEM_YMU759, 64, 0, 0,
-        0
-      }
-    ));
-  }
-  sysCategories.push_back(cat);
-
-  cat=FurnaceGUISysCategory("Square","these chips generate square/pulse tones only (but may include noise).");
-  cat.systems.push_back(FurnaceGUISysDef(
-    "TI SN76489", {
-      DIV_SYSTEM_SMS, 64, 0, 4,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "TI SN76489A", {
-      DIV_SYSTEM_SMS, 64, 0, 0x40,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "TI SN76496", {
-      DIV_SYSTEM_SMS, 64, 0, 0x44,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "NCR 8496", {
-      DIV_SYSTEM_SMS, 64, 0, 0x48,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Tandy PSSJ 3-voice sound", {
-      DIV_SYSTEM_SMS, 64, 0, 0x4c,
-      // 8 bit DAC
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Sega PSG (SN76489-like)", {
-      DIV_SYSTEM_SMS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Sega PSG (SN76489-like, Stereo)", {
-      DIV_SYSTEM_SMS, 64, 0, 0xc,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "TI SN94624", {
-      DIV_SYSTEM_SMS, 64, 0, 0x182,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "TI SN76494", {
-      DIV_SYSTEM_SMS, 64, 0, 0x186,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Toshiba T6W28", {
-      DIV_SYSTEM_T6W28, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "AY-3-8910", {
-      DIV_SYSTEM_AY8910, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "AY-3-8914", {
-      DIV_SYSTEM_AY8910, 64, 0, 48,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YM2149(F)", {
-      DIV_SYSTEM_AY8910, 64, 0, 16,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Philips SAA1099", {
-      DIV_SYSTEM_SAA1099, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "PC Speaker", {
-      DIV_SYSTEM_PCSPKR, 32, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Commodore VIC", {
-      DIV_SYSTEM_VIC20, 64, 0, 1,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "OKI MSM5232", {
-      DIV_SYSTEM_MSM5232, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Pong", {
-      DIV_SYSTEM_PONG, 64, 0, 0,
-      0
-    }
-  ));
-  sysCategories.push_back(cat);
-
-  cat=FurnaceGUISysCategory("Sample","chips/systems which use PCM or ADPCM samples for sound synthesis.");
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Amiga", {
-      DIV_SYSTEM_AMIGA, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "SegaPCM", {
-      DIV_SYSTEM_SEGAPCM, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Capcom QSound", {
-      DIV_SYSTEM_QSOUND, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Seta/Allumer X1-010", {
-      DIV_SYSTEM_X1_010, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Yamaha YMZ280B (PCMD8)", {
-      DIV_SYSTEM_YMZ280B, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Ricoh RF5C68", {
-      DIV_SYSTEM_RF5C68, 64, 0, 0,
-      0
-    }
-  )); 
-  cat.systems.push_back(FurnaceGUISysDef(
-    "OKI MSM6258", {
-      DIV_SYSTEM_MSM6258, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "OKI MSM6295", {
-      DIV_SYSTEM_MSM6295, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "SNES", {
-      DIV_SYSTEM_SNES, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Generic PCM DAC", {
-      DIV_SYSTEM_PCM_DAC, 64, 0, 0,
-      0
-    }
-  ));
-  sysCategories.push_back(cat);
-
-  cat=FurnaceGUISysCategory("Wavetable","chips which use user-specified waveforms to generate sound.");
-  cat.systems.push_back(FurnaceGUISysDef(
-    "PC Engine", {
-      DIV_SYSTEM_PCE, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Commodore PET (pseudo-wavetable)", {
-      DIV_SYSTEM_PET, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Konami Bubble System WSG", {
-      DIV_SYSTEM_BUBSYS_WSG, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Konami SCC", {
-      DIV_SYSTEM_SCC, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Konami SCC+", {
-      DIV_SYSTEM_SCC_PLUS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Namco WSG", {
-      DIV_SYSTEM_NAMCO, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Namco C15 (8-channel mono)", {
-      DIV_SYSTEM_NAMCO_15XX, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Namco C30 (8-channel stereo)", {
-      DIV_SYSTEM_NAMCO_CUS30, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Namco 163", {
-      DIV_SYSTEM_N163, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Famicom Disk System (chip)", {
-      DIV_SYSTEM_FDS, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "WonderSwan", {
-      DIV_SYSTEM_SWAN, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Virtual Boy", {
-      DIV_SYSTEM_VBOY, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Seta/Allumer X1-010", {
-      DIV_SYSTEM_X1_010, 64, 0, 0,
-      0
-    }
-  ));
-  sysCategories.push_back(cat);
-
-  cat=FurnaceGUISysCategory("Specialized","chips/systems with unique sound synthesis methods.");
-  cat.systems.push_back(FurnaceGUISysDef(
-    "MOS Technology SID (6581)", {
-      DIV_SYSTEM_C64_6581, 64, 0, 1,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "MOS Technology SID (8580)", {
-      DIV_SYSTEM_C64_8580, 64, 0, 1,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Microchip AY8930", {
-      DIV_SYSTEM_AY8930, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Game Boy", {
-      DIV_SYSTEM_GB, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Atari Lynx", {
-      DIV_SYSTEM_LYNX, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Atari TIA", {
-      DIV_SYSTEM_TIA, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "NES (Ricoh 2A03)", {
-      DIV_SYSTEM_NES, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "Commander X16 (VERA only)", {
-      DIV_SYSTEM_VERA, 64, 0, 0,
-      0
-    }
-  ));
-  cat.systems.push_back(FurnaceGUISysDef(
-    "ZX Spectrum (beeper only)", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
-      0
-    }
-  ));
-  if (settings.hiddenSystems) {
-    cat.systems.push_back(FurnaceGUISysDef(
-      "Dummy System", {
-        DIV_SYSTEM_DUMMY, 64, 0, 0,
-        0
-      }
-    ));
-  }
-  cat.systems.push_back(FurnaceGUISysDef(
-    "tildearrow Sound Unit", {
-      DIV_SYSTEM_SOUND_UNIT, 64, 0, 0,
-      0
-    }
-  ));
-  sysCategories.push_back(cat);
-
   cat=FurnaceGUISysCategory("Arcade systems","INSERT COIN");
   cat.systems.push_back(FurnaceGUISysDef(
     "Pong", {
@@ -2318,6 +1812,512 @@ void FurnaceGUI::initSystemPresets() {
   cat.systems.push_back(FurnaceGUISysDef(
     "Neo Geo CD (extended channel 2)", {
       DIV_SYSTEM_YM2610_EXT, 64, 0, 0,
+      0
+    }
+  ));
+  sysCategories.push_back(cat);
+
+  cat=FurnaceGUISysCategory("FM","chips which use frequency modulation (FM) to generate sound.\nsome of these also pack more (like square and sample channels).");
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2151 (OPM)", {
+      DIV_SYSTEM_YM2151, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2203 (OPN)", {
+      DIV_SYSTEM_OPN, 64, 0, 3,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2203 (extended channel 3)", {
+      DIV_SYSTEM_OPN_EXT, 64, 0, 3,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2608 (OPNA)", {
+      DIV_SYSTEM_PC98, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2608 (extended channel 3)", {
+      DIV_SYSTEM_PC98_EXT, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2610 (OPNB)", {
+      DIV_SYSTEM_YM2610_FULL, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2610 (extended channel 2)", {
+      DIV_SYSTEM_YM2610_FULL_EXT, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2610B (OPNB2)", {
+      DIV_SYSTEM_YM2610B, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2610B (extended channel 3)", {
+      DIV_SYSTEM_YM2610B_EXT, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2612 (OPN2)", {
+      DIV_SYSTEM_YM2612, 64, 0, (int)0x80000000,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2612 (extended channel 3)", {
+      DIV_SYSTEM_YM2612_EXT, 64, 0, (int)0x80000000,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2612 (OPN2) with DualPCM", {
+      DIV_SYSTEM_YM2612_FRAC, 64, 0, (int)0x80000000,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2612 (extended channel 3) with DualPCM", {
+      DIV_SYSTEM_YM2612_FRAC_EXT, 64, 0, (int)0x80000000,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2413 (OPLL)", {
+      DIV_SYSTEM_OPLL, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2413 (drums mode)", {
+      DIV_SYSTEM_OPLL_DRUMS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2414 (OPZ)", {
+      DIV_SYSTEM_OPZ, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3438 (OPN2C)", {
+      DIV_SYSTEM_YM2612, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3438 (extended channel 3)", {
+      DIV_SYSTEM_YM2612_EXT, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3438 (OPN2C) with DualPCM", {
+      DIV_SYSTEM_YM2612_FRAC, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3438 (extended channel 3) with DualPCM", {
+      DIV_SYSTEM_YM2612_FRAC_EXT, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3526 (OPL)", {
+      DIV_SYSTEM_OPL, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3526 (drums mode)", {
+      DIV_SYSTEM_OPL_DRUMS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha Y8950", {
+      DIV_SYSTEM_Y8950, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha Y8950 (drums mode)", {
+      DIV_SYSTEM_Y8950_DRUMS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3812 (OPL2)", {
+      DIV_SYSTEM_OPL2, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM3812 (drums mode)", {
+      DIV_SYSTEM_OPL2_DRUMS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YMF262 (OPL3)", {
+      DIV_SYSTEM_OPL3, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YMF262 (drums mode)", {
+      DIV_SYSTEM_OPL3_DRUMS, 64, 0, 0,
+      0
+    }
+  ));
+  if (settings.hiddenSystems) {
+    cat.systems.push_back(FurnaceGUISysDef(
+      "Yamaha YMU759 (MA-2)", {
+        DIV_SYSTEM_YMU759, 64, 0, 0,
+        0
+      }
+    ));
+  }
+  sysCategories.push_back(cat);
+
+  cat=FurnaceGUISysCategory("Square","these chips generate square/pulse tones only (but may include noise).");
+  cat.systems.push_back(FurnaceGUISysDef(
+    "TI SN76489", {
+      DIV_SYSTEM_SMS, 64, 0, 4,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "TI SN76489A", {
+      DIV_SYSTEM_SMS, 64, 0, 0x40,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "TI SN76496", {
+      DIV_SYSTEM_SMS, 64, 0, 0x44,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "NCR 8496", {
+      DIV_SYSTEM_SMS, 64, 0, 0x48,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Tandy PSSJ 3-voice sound", {
+      DIV_SYSTEM_SMS, 64, 0, 0x4c,
+      // 8 bit DAC
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Sega PSG (SN76489-like)", {
+      DIV_SYSTEM_SMS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Sega PSG (SN76489-like, Stereo)", {
+      DIV_SYSTEM_SMS, 64, 0, 0xc,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "TI SN94624", {
+      DIV_SYSTEM_SMS, 64, 0, 0x182,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "TI SN76494", {
+      DIV_SYSTEM_SMS, 64, 0, 0x186,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Toshiba T6W28", {
+      DIV_SYSTEM_T6W28, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "AY-3-8910", {
+      DIV_SYSTEM_AY8910, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "AY-3-8914", {
+      DIV_SYSTEM_AY8910, 64, 0, 48,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YM2149(F)", {
+      DIV_SYSTEM_AY8910, 64, 0, 16,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Philips SAA1099", {
+      DIV_SYSTEM_SAA1099, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "PC Speaker", {
+      DIV_SYSTEM_PCSPKR, 32, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Commodore VIC", {
+      DIV_SYSTEM_VIC20, 64, 0, 1,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "OKI MSM5232", {
+      DIV_SYSTEM_MSM5232, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Pong", {
+      DIV_SYSTEM_PONG, 64, 0, 0,
+      0
+    }
+  ));
+  sysCategories.push_back(cat);
+
+  cat=FurnaceGUISysCategory("Sample","chips/systems which use PCM or ADPCM samples for sound synthesis.");
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Amiga", {
+      DIV_SYSTEM_AMIGA, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "SegaPCM", {
+      DIV_SYSTEM_SEGAPCM, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Capcom QSound", {
+      DIV_SYSTEM_QSOUND, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Seta/Allumer X1-010", {
+      DIV_SYSTEM_X1_010, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Yamaha YMZ280B (PCMD8)", {
+      DIV_SYSTEM_YMZ280B, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Ricoh RF5C68", {
+      DIV_SYSTEM_RF5C68, 64, 0, 0,
+      0
+    }
+  )); 
+  cat.systems.push_back(FurnaceGUISysDef(
+    "OKI MSM6258", {
+      DIV_SYSTEM_MSM6258, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "OKI MSM6295", {
+      DIV_SYSTEM_MSM6295, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "SNES", {
+      DIV_SYSTEM_SNES, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Generic PCM DAC", {
+      DIV_SYSTEM_PCM_DAC, 64, 0, 0,
+      0
+    }
+  ));
+  sysCategories.push_back(cat);
+
+  cat=FurnaceGUISysCategory("Wavetable","chips which use user-specified waveforms to generate sound.");
+  cat.systems.push_back(FurnaceGUISysDef(
+    "PC Engine", {
+      DIV_SYSTEM_PCE, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Commodore PET (pseudo-wavetable)", {
+      DIV_SYSTEM_PET, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Konami Bubble System WSG", {
+      DIV_SYSTEM_BUBSYS_WSG, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Konami SCC", {
+      DIV_SYSTEM_SCC, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Konami SCC+", {
+      DIV_SYSTEM_SCC_PLUS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Namco WSG", {
+      DIV_SYSTEM_NAMCO, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Namco C15 (8-channel mono)", {
+      DIV_SYSTEM_NAMCO_15XX, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Namco C30 (8-channel stereo)", {
+      DIV_SYSTEM_NAMCO_CUS30, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Namco 163", {
+      DIV_SYSTEM_N163, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Famicom Disk System (chip)", {
+      DIV_SYSTEM_FDS, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "WonderSwan", {
+      DIV_SYSTEM_SWAN, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Virtual Boy", {
+      DIV_SYSTEM_VBOY, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Seta/Allumer X1-010", {
+      DIV_SYSTEM_X1_010, 64, 0, 0,
+      0
+    }
+  ));
+  sysCategories.push_back(cat);
+
+  cat=FurnaceGUISysCategory("Specialized","chips/systems with unique sound synthesis methods.");
+  cat.systems.push_back(FurnaceGUISysDef(
+    "MOS Technology SID (6581)", {
+      DIV_SYSTEM_C64_6581, 64, 0, 1,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "MOS Technology SID (8580)", {
+      DIV_SYSTEM_C64_8580, 64, 0, 1,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Microchip AY8930", {
+      DIV_SYSTEM_AY8930, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Game Boy", {
+      DIV_SYSTEM_GB, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Atari Lynx", {
+      DIV_SYSTEM_LYNX, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Atari TIA", {
+      DIV_SYSTEM_TIA, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "NES (Ricoh 2A03)", {
+      DIV_SYSTEM_NES, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "Commander X16 (VERA only)", {
+      DIV_SYSTEM_VERA, 64, 0, 0,
+      0
+    }
+  ));
+  cat.systems.push_back(FurnaceGUISysDef(
+    "ZX Spectrum (beeper only)", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
+      0
+    }
+  ));
+  if (settings.hiddenSystems) {
+    cat.systems.push_back(FurnaceGUISysDef(
+      "Dummy System", {
+        DIV_SYSTEM_DUMMY, 64, 0, 0,
+        0
+      }
+    ));
+  }
+  cat.systems.push_back(FurnaceGUISysDef(
+    "tildearrow Sound Unit", {
+      DIV_SYSTEM_SOUND_UNIT, 64, 0, 0,
       0
     }
   ));


### PR DESCRIPTION
Puts Arcade and Deflemask-Compatible back right under Game Consoles and Computers