### PR TITLE
Update AY8930 doc

### DIFF
--- a/papers/doc/7-systems/ay8930.md
+++ b/papers/doc/7-systems/ay8930.md
@@ -3,7 +3,7 @@
 a backwards-compatible successor to the AY-3-8910, with increased volume resolution, duty cycle control, three envelopes and highly configurable noise generator.
 
 sadly, this soundchip has only ever observed minimal success, and has remained rather obscure since.
-it is known for being used in the Covox Sound Master, which didn't sell well either.
+it is best known for being used in the Covox Sound Master, which didn't sell well either. It also observed very minimal success in Merit's CRT-250 machines, but only as a replacement for the AY-3-8910.
 
 emulation of this chip in Furnace is now complete thanks to community efforts and hardware testing, which an MSX board called Darky has permitted.
 


### PR DESCRIPTION
I own several arcade boards. the CRT-250 by Merit Industries has two of them on the board, and their CRT-260 specifies an AY8930 on the board, but uses YM2149 chips despite the board's labeled specification. 

addendum: as the CRT-260 simply is just a cost reduced CRT-250, the hardware is effectively the same, so i only specified the CRT-250.