### PR TITLE
Create SNES instrument from BRR sample

### DIFF
--- a/src/gui/doAction.cpp
+++ b/src/gui/doAction.cpp
@@ -259,7 +259,7 @@ void FurnaceGUI::doAction(int what) {
     case GUI_ACTION_WINDOW_FIND:
       nextWindow=GUI_WINDOW_FIND;
       break;
-    
+
     case GUI_ACTION_COLLAPSE_WINDOW:
       collapseWindow=true;
       break;
@@ -637,7 +637,7 @@ void FurnaceGUI::doAction(int what) {
       wantScrollList=true;
       wavePreviewInit=true;
       break;
-    
+
     case GUI_ACTION_WAVE_LIST_ADD:
       curWave=e->addWave();
       if (curWave==-1) {
@@ -1296,7 +1296,9 @@ void FurnaceGUI::doAction(int what) {
       if (curIns==-1) {
         showError("too many instruments!");
       } else {
-        e->song.ins[curIns]->type=DIV_INS_AMIGA;
+        e->song.ins[curIns]->type = (sample->depth == DIV_SAMPLE_DEPTH_BRR)
+          ? DIV_INS_SNES
+          : DIV_INS_AMIGA;
         e->song.ins[curIns]->name=sample->name;
         e->song.ins[curIns]->amiga.initSample=curSample;
         nextWindow=GUI_WINDOW_INS_EDIT;


### PR DESCRIPTION
Previously, clicking the "Create instrument from sample" button in the "Sample Editor" window would create a "Generic Sample". This is a problem since it can't control the SNES ADSR envelopes, it seems to produce no sound on a SNES chip, and the "Generic Sample" option isn't even available in the instrument type dropdown if you only have the SNES chip in a module (the dropdown contains only SNES).

## Unresolved issues

Perhaps this should be generalized to more sample and instrument types. Perhaps you should create a separate function mapping from `DivSampleDepth` or `DivSample const&` to `DivInstrumentType`?

Additionally should you pick sample types based on the currently enabled chips? **Even after this PR, converting a .wav imported sample to instrument will create a "Generic Sample" instrument, which is still unusable on SNES**. But if you have multiple chips enabled, should you pick an instrument type based on the sample type, the sample type if the current chip(s?) support it, or the current chips only? And if you use the current chips, do you use the leftmost chip, or the current cursor position?

In short this is very much an open problem, and this should not be merged as-is. And frankly I feel supporting dozens of disparate sound chips with unique quirks, in a single tracker, is bound to produce thorny issues without clean resolutions like this.