### PR TITLE
fix YM2151 LFO shapes, correct some presets

### DIFF
--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -411,7 +411,7 @@ String macroLFOWaves(int id, float val, void* u) {
     case 1:
       return "Square";
     case 2:
-      return "Sine";
+      return "Triangle";
     case 3:
       return "Random";
     default:

--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -440,14 +440,14 @@ void FurnaceGUI::initSystemPresets() {
   cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-26/K)", {
       DIV_SYSTEM_OPN, 64, 0, 4, // 3.9936MHz but some compatible card has 4MHz
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-26/K; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4, // 3.9936MHz but some compatible card has 4MHz
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -455,7 +455,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_OPL2, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -463,7 +463,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_OPL2, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -471,7 +471,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra in drums mode)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_OPL2_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -479,7 +479,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra in drums mode; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_OPL2_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -487,7 +487,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_Y8950, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -495,7 +495,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_Y8950, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -503,7 +503,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V in drums mode)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_Y8950_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -511,7 +511,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V in drums mode; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_Y8950_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -520,7 +520,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_PC98, 64, 0, 1,
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16), // 2x 16-bit Burr Brown DAC
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
-      DIV_SYSTEM_PCSPKR, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -529,21 +529,21 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_PC98_EXT, 64, 0, 1,
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
-      DIV_SYSTEM_PCSPKR, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
     cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-73)", {
       DIV_SYSTEM_PC98, 64, 0, 1,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
     cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-73; extended channel 3)", {
       DIV_SYSTEM_PC98_EXT, 64, 0, 1,
-      DIV_SYSTEM_PCSPKR, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -552,7 +552,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3, 64, 0, 0,
-      DIV_SYSTEM_PCSPKR, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -561,7 +561,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN_EXT, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3, 64, 0, 0,
-      DIV_SYSTEM_PCSPKR, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -570,7 +570,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3_DRUMS, 64, 0, 2,
-      DIV_SYSTEM_PCSPKR, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -579,7 +579,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN_EXT, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3_DRUMS, 64, 0, 2,
-      DIV_SYSTEM_PCSPKR, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));

--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -440,12 +440,14 @@ void FurnaceGUI::initSystemPresets() {
   cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-26/K)", {
       DIV_SYSTEM_OPN, 64, 0, 4, // 3.9936MHz but some compatible card has 4MHz
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-26/K; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4, // 3.9936MHz but some compatible card has 4MHz
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -453,6 +455,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_OPL2, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -460,6 +463,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_OPL2, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -467,6 +471,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra in drums mode)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_OPL2_DRUMS, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -474,6 +479,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra in drums mode; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_OPL2_DRUMS, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -481,6 +487,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_Y8950, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -488,6 +495,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_Y8950, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -495,6 +503,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V in drums mode)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_Y8950_DRUMS, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -502,6 +511,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V in drums mode; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_Y8950_DRUMS, 64, 0, 4,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -510,6 +520,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_PC98, 64, 0, 1,
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16), // 2x 16-bit Burr Brown DAC
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -518,18 +529,21 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_PC98_EXT, 64, 0, 1,
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
     cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-73)", {
       DIV_SYSTEM_PC98, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
     cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-73; extended channel 3)", {
       DIV_SYSTEM_PC98_EXT, 64, 0, 1,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -538,6 +552,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -546,6 +561,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN_EXT, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -554,6 +570,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3_DRUMS, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
@@ -562,24 +579,26 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN_EXT, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3_DRUMS, 64, 0, 2,
+      DIV_SYSTEM_PCSPKR, 64, 0, 0,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (48K)", {
-      DIV_SYSTEM_AY8910, 64, 0, 2,
       DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K)", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
@@ -588,6 +607,7 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM (extended channel 3 on first OPN)", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
@@ -596,6 +616,7 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM (extended channel 3 on second OPN)", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
@@ -604,6 +625,7 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM (extended channel 3 on both OPNs)", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
@@ -612,6 +634,7 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound", {
+      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_AY8910, 64, 0, 1, // or YM2149
       DIV_SYSTEM_AY8910, 64, 0, 1, // or YM2149

--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -591,14 +591,12 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K)", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
-      DIV_SYSTEM_AY8910, 64, 0, 1,
+      DIV_SYSTEM_AY8910, 64, 0, 1, //beeper was also included
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
@@ -607,7 +605,6 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM (extended channel 3 on first OPN)", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
@@ -616,7 +613,6 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM (extended channel 3 on second OPN)", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
@@ -625,7 +621,6 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound FM (extended channel 3 on both OPNs)", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
       DIV_SYSTEM_OPN_EXT, 64, 0, 1,
@@ -634,7 +629,6 @@ void FurnaceGUI::initSystemPresets() {
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "ZX Spectrum (128K) with TurboSound", {
-      DIV_SYSTEM_SFX_BEEPER, 64, 0, 0,
       DIV_SYSTEM_AY8910, 64, 0, 1,
       DIV_SYSTEM_AY8910, 64, 0, 1, // or YM2149
       DIV_SYSTEM_AY8910, 64, 0, 1, // or YM2149

--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -440,14 +440,14 @@ void FurnaceGUI::initSystemPresets() {
   cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-26/K)", {
       DIV_SYSTEM_OPN, 64, 0, 4, // 3.9936MHz but some compatible card has 4MHz
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
   cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-26/K; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4, // 3.9936MHz but some compatible card has 4MHz
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -455,7 +455,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_OPL2, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -463,7 +463,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_OPL2, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -471,7 +471,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra in drums mode)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_OPL2_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -479,7 +479,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra in drums mode; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_OPL2_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -487,7 +487,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_Y8950, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -495,7 +495,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_Y8950, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -503,7 +503,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V in drums mode)", {
       DIV_SYSTEM_OPN, 64, 0, 4,
       DIV_SYSTEM_Y8950_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -511,7 +511,7 @@ void FurnaceGUI::initSystemPresets() {
     "NEC PC-98 (with Sound Orchestra V in drums mode; extended channel 3)", {
       DIV_SYSTEM_OPN_EXT, 64, 0, 4,
       DIV_SYSTEM_Y8950_DRUMS, 64, 0, 4,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -520,7 +520,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_PC98, 64, 0, 1,
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16), // 2x 16-bit Burr Brown DAC
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 2,
       0
     }
   ));
@@ -529,21 +529,21 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_PC98_EXT, 64, 0, 1,
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16),
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 2,
       0
     }
   ));
     cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-73)", {
       DIV_SYSTEM_PC98, 64, 0, 1,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
     cat.systems.push_back(FurnaceGUISysDef(
     "NEC PC-98 (with PC-9801-73; extended channel 3)", {
       DIV_SYSTEM_PC98_EXT, 64, 0, 1,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 1,
       0
     }
   ));
@@ -552,7 +552,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3, 64, 0, 0,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 2,
       0
     }
   ));
@@ -561,7 +561,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN_EXT, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3, 64, 0, 0,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 2,
       0
     }
   ));
@@ -570,7 +570,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3_DRUMS, 64, 0, 2,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 2,
       0
     }
   ));
@@ -579,7 +579,7 @@ void FurnaceGUI::initSystemPresets() {
       DIV_SYSTEM_OPN_EXT, 64, 0, 2, // 4MHz
       DIV_SYSTEM_PCM_DAC, 64, 0, 44099|(15<<16)|(1<<20),
       DIV_SYSTEM_OPL3_DRUMS, 64, 0, 2,
-      DIV_SYSTEM_PCSPKR, 64, 0, 0,
+      DIV_SYSTEM_PCSPKR, 64, 0, 2,
       0
     }
   ));


### PR DESCRIPTION
Some were confused about ZX Spectrum sound hardware. 48k model had only beeper (with later optional AY modules) and 128k model didnt remove beeper. Also, ZX and IBM PC werent only system that utilized beeper so added PCSPKR to PC-9801 as well.

Would add it to MSX, but I dont know if MSX key-click does it differently (see PET or PokeMini)

Also YM2151 LFO shapes were wrong, finally fixed