### PR TITLE
ASAP POKEY small fix and refactorings

### DIFF
--- a/src/engine/platform/pokey.cpp
+++ b/src/engine/platform/pokey.cpp
@@ -456,7 +456,6 @@ void DivPlatformPOKEY::setFlags(const DivConfig& flags) {
     }
     altASAP.init(chipClock,rate);
   } else {
-    MZPOKEYSND_Init(&pokey);
     rate=chipClock;
     for (int i=0; i<4; i++) {
       oscBuf[i]->rate=rate/14;
@@ -480,6 +479,10 @@ int DivPlatformPOKEY::init(DivEngine* p, int channels, int sugRate, const DivCon
   for (int i=0; i<4; i++) {
     isMuted[i]=false;
     oscBuf[i]=new DivDispatchOscBuffer;
+  }
+
+  if (!useAltASAP) {
+    MZPOKEYSND_Init(&pokey);
   }
 
   setFlags(flags);

--- a/src/engine/platform/pokey.cpp
+++ b/src/engine/platform/pokey.cpp
@@ -96,16 +96,16 @@ void DivPlatformPOKEY::acquireMZ(short* buf, size_t start, size_t len) {
 void DivPlatformPOKEY::acquireASAP(short* buf, size_t start, size_t len) {
   while (!writes.empty()) {
     QueuedWrite w=writes.front();
-    altASAP->write(w.addr, w.val);
+    altASAP.write(w.addr, w.val);
     writes.pop();
   }
 
   for (size_t h=start; h<start+len; h++) {
     if (++oscBufDelay>=2) {
       oscBufDelay=0;
-      buf[h]=altASAP->sampleAudio(oscBuf);
+      buf[h]=altASAP.sampleAudio(oscBuf);
     } else {
-      buf[h]=altASAP->sampleAudio();
+      buf[h]=altASAP.sampleAudio();
     }
   }
 }
@@ -396,7 +396,7 @@ DivDispatchOscBuffer* DivPlatformPOKEY::getOscBuffer(int ch) {
 
 unsigned char* DivPlatformPOKEY::getRegisterPool() {
   if (useAltASAP) {
-    return const_cast<unsigned char*>(altASAP->getRegisterPool());
+    return const_cast<unsigned char*>(altASAP.getRegisterPool());
   } else {
     return regPool;
   }
@@ -418,7 +418,7 @@ void DivPlatformPOKEY::reset() {
   }
 
   if (useAltASAP) {
-    altASAP->reset();
+    altASAP.reset();
   } else {
     ResetPokeyState(&pokey);
   }
@@ -454,11 +454,9 @@ void DivPlatformPOKEY::setFlags(const DivConfig& flags) {
     for (int i=0; i<4; i++) {
       oscBuf[i]->rate=rate/2;
     }
-    if (altASAP) {
-      delete altASAP;
-    }
-    altASAP=new AltASAP::Pokey(chipClock,rate);
+    altASAP.init(chipClock,rate);
   } else {
+    MZPOKEYSND_Init(&pokey);
     rate=chipClock;
     for (int i=0; i<4; i++) {
       oscBuf[i]->rate=rate/14;
@@ -479,16 +477,11 @@ int DivPlatformPOKEY::init(DivEngine* p, int channels, int sugRate, const DivCon
   dumpWrites=false;
   skipRegisterWrites=false;
   oscBufDelay=0;
-  altASAP=NULL;
   for (int i=0; i<4; i++) {
     isMuted[i]=false;
     oscBuf[i]=new DivDispatchOscBuffer;
   }
 
-  if (!useAltASAP) {
-    MZPOKEYSND_Init(&pokey);
-  }
-  
   setFlags(flags);
   reset();
   return 6;
@@ -497,9 +490,6 @@ int DivPlatformPOKEY::init(DivEngine* p, int channels, int sugRate, const DivCon
 void DivPlatformPOKEY::quit() {
   for (int i=0; i<4; i++) {
     delete oscBuf[i];
-  }
-  if (altASAP) {
-    delete altASAP;
   }
 }
 

--- a/src/engine/platform/pokey.h
+++ b/src/engine/platform/pokey.h
@@ -52,7 +52,7 @@ class DivPlatformPOKEY: public DivDispatch {
   bool audctlChanged;
   unsigned char oscBufDelay;
   PokeyState pokey;
-  AltASAP::Pokey* altASAP;
+  AltASAP::Pokey altASAP;
   bool useAltASAP;
   unsigned char regPool[16];
   friend void putDispatchChip(void*,int);

--- a/src/engine/platform/sound/pokey/AltASAP.cpp
+++ b/src/engine/platform/sound/pokey/AltASAP.cpp
@@ -494,10 +494,12 @@ public:
       int64_t value = mQueue->pop();
       if ( ( value & 7 ) == 6 ) // 6 == 4 ^ 2
       {
-        int16_t ch0 = mAudioChannels[0].getOutput();
-        int16_t ch1 = mAudioChannels[1].getOutput();
-        int16_t ch2 = mAudioChannels[2].getOutput();
-        int16_t ch3 = mAudioChannels[3].getOutput();
+        //just some magick value to match the audio level of mzpokeysnd
+        static constexpr int16_t MAGICK_VOLUME_BOOSTER = 160;
+        int16_t ch0 = mAudioChannels[0].getOutput() * MAGICK_VOLUME_BOOSTER;
+        int16_t ch1 = mAudioChannels[1].getOutput() * MAGICK_VOLUME_BOOSTER;
+        int16_t ch2 = mAudioChannels[2].getOutput() * MAGICK_VOLUME_BOOSTER;
+        int16_t ch3 = mAudioChannels[3].getOutput() * MAGICK_VOLUME_BOOSTER;
 
         if ( oscb != nullptr )
         {
@@ -626,7 +628,7 @@ void Pokey::write( uint8_t address, uint8_t value )
 
 int16_t Pokey::sampleAudio( DivDispatchOscBuffer** oscb )
 {
-  return mPokey->sampleAudio( oscb ) * 160; //just some magick value to match the audio level of mzpokeysnd
+  return mPokey->sampleAudio( oscb );
 }
 
 uint8_t const* Pokey::getRegisterPool()

--- a/src/engine/platform/sound/pokey/AltASAP.cpp
+++ b/src/engine/platform/sound/pokey/AltASAP.cpp
@@ -283,9 +283,8 @@ public:
 
   PokeyPimpl( uint32_t pokeyClock, uint32_t sampleRate ) : PokeyBase{}, mQueue{ std::make_unique<ActionQueue>() },
     mAudioChannels{ AudioChannel{ *mQueue, 0u }, AudioChannel{ *mQueue, 1u }, AudioChannel{ *mQueue, 2u }, AudioChannel{ *mQueue, 3u } },
-    mRegisterPool{}, mPokeyClock{ pokeyClock * 8 }, mTick{}, mNextTick{}, mSampleRate{ sampleRate }, mSamplesRemainder{},
-    mReloadCycles1{ 28 }, mReloadCycles3{ 28 }, mDivCycles{ 28 },
-    mTicksPerSample{ mPokeyClock / mSampleRate, mPokeyClock % mSampleRate }
+    mRegisterPool{}, mTick{}, mNextTick{}, mReloadCycles1{ 28 }, mReloadCycles3{ 28 }, mDivCycles{ 28 }, mSampleRate{ sampleRate }, mSamplesRemainder{},
+    mTicksPerSample{ ( pokeyClock * 8 ) / mSampleRate, ( pokeyClock * 8 ) % mSampleRate }
   {
     std::fill_n( mRegisterPool.data(), mRegisterPool.size(), (uint8_t)0xff );
     enqueueSampling();
@@ -468,7 +467,7 @@ public:
       for ( int i = 0; i < 4; i++ )
         mAudioChannels[i].doStimer( cycle );
       break;
-    case 0x0f:                                                                               
+    case 0x0f:
     {
       if ( value == mSkctl )
         break;
@@ -600,21 +599,31 @@ private:
 
   std::array<uint8_t, 4 * 2 + 1> mRegisterPool;
 
-  uint32_t mPokeyClock;
   uint64_t mTick;
   uint64_t mNextTick;
+  int64_t mReloadCycles1;
+  int64_t mReloadCycles3;
+  int64_t mDivCycles;
   uint32_t mSampleRate;
   uint32_t mSamplesRemainder;
-  int mReloadCycles1;
-  int mReloadCycles3;
-  int mDivCycles;
   std::pair<uint32_t, uint32_t> mTicksPerSample;
-
 };
 
-
-Pokey::Pokey( uint32_t pokeyClock, uint32_t sampleRate ) : mPokey{ std::make_unique<PokeyPimpl>( mPokeyClock, mSampleRate ) }, mPokeyClock{ pokeyClock }, mSampleRate{ sampleRate }
+//Initializing periods with safe defaults
+Pokey::Pokey() : mPokeyClock{ (uint32_t)COLOR_NTSC / 2 }, mSampleRate{ mPokeyClock / 7 }, mPokey{}
 {
+}
+
+void Pokey::init( uint32_t pokeyClock, uint32_t sampleRate )
+{
+  mPokey.reset();
+  mPokeyClock = pokeyClock;
+  mSampleRate = sampleRate;
+}
+
+void Pokey::reset()
+{
+  mPokey = std::make_unique<PokeyPimpl>( mPokeyClock, mSampleRate );
 }
 
 Pokey::~Pokey()
@@ -623,22 +632,20 @@ Pokey::~Pokey()
 
 void Pokey::write( uint8_t address, uint8_t value )
 {
+  assert( mPokey );
   mPokey->write( address, value );
 }
 
 int16_t Pokey::sampleAudio( DivDispatchOscBuffer** oscb )
 {
+  assert( mPokey );
   return mPokey->sampleAudio( oscb );
 }
 
 uint8_t const* Pokey::getRegisterPool()
 {
+  assert( mPokey );
   return mPokey->getRegisterPool();
-}
-
-void Pokey::reset()
-{
-  mPokey = std::make_unique<PokeyPimpl>( mPokeyClock, mSampleRate );
 }
 
 }

--- a/src/engine/platform/sound/pokey/AltASAP.hpp
+++ b/src/engine/platform/sound/pokey/AltASAP.hpp
@@ -15,7 +15,8 @@ class Pokey
 {
 public:
 
-  Pokey( uint32_t pokeyClock, uint32_t sampleRate );
+  Pokey();
+  void init( uint32_t pokeyClock, uint32_t sampleRate );
   ~Pokey();
 
   void write( uint8_t address, uint8_t value );
@@ -26,10 +27,9 @@ public:
   void reset();
 
 private:
-
-  std::unique_ptr<PokeyPimpl> mPokey;
   uint32_t mPokeyClock;
   uint32_t mSampleRate;
+  std::unique_ptr<PokeyPimpl> mPokey;
 };
 
 }


### PR DESCRIPTION
<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->

Fixed oscilloscopes volume.
Refactored `AltASAP::Pokey` instance to be direct member of `DivPlatformPOKEY` and moved initialization to the core.