### PR TITLE
POKEY: audc is set for wrong channel when channels 3 & 4 are paired

### DIFF
--- a/src/engine/platform/pokey.cpp
+++ b/src/engine/platform/pokey.cpp
@@ -241,7 +241,7 @@ void DivPlatformPOKEY::tick(bool sysTick) {
       chan[i].ctlChanged=false;
       if ((i==1 && audctl&16) || (i==3 && audctl&8)) {
         // ignore - channel is paired
-      } else if ((i==0 && audctl&16) || (i==0 && audctl&8)) {
+      } else if ((i==0 && audctl&16) || (i==2 && audctl&8)) {
         rWrite(1+(i<<1),0);
         rWrite(3+(i<<1),val);
       } else {


### PR DESCRIPTION
<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->

Obvious typo found while experimenting with 16-bit channels.