### PR TITLE
Option to move the cursor along with order upon moving order up/down

### DIFF
--- a/src/gui/doAction.cpp
+++ b/src/gui/doAction.cpp
@@ -1514,11 +1514,17 @@ void FurnaceGUI::doAction(int what) {
     case GUI_ACTION_ORDERS_MOVE_UP:
       prepareUndo(GUI_UNDO_CHANGE_ORDER);
       e->moveOrderUp(curOrder);
+      if (settings.cursorFollowsOrder) {
+        e->setOrder(curOrder);
+      }
       makeUndo(GUI_UNDO_CHANGE_ORDER);
       break;
     case GUI_ACTION_ORDERS_MOVE_DOWN:
       prepareUndo(GUI_UNDO_CHANGE_ORDER);
       e->moveOrderDown(curOrder);
+      if (settings.cursorFollowsOrder) {
+        e->setOrder(curOrder);
+      }
       makeUndo(GUI_UNDO_CHANGE_ORDER);
       break;
     case GUI_ACTION_ORDERS_REPLAY:

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1340,6 +1340,7 @@ class FurnaceGUI {
     int doubleClickColumn;
     int blankIns;
     int dragMovesSelection;
+    int cursorFollowsOrder;
     int unsignedDetune;
     int noThreadedInput;
     int saveWindowPos;
@@ -1480,6 +1481,7 @@ class FurnaceGUI {
       doubleClickColumn(1),
       blankIns(0),
       dragMovesSelection(1),
+      cursorFollowsOrder(0),
       unsignedDetune(0),
       noThreadedInput(0),
       clampSamples(0),

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -652,6 +652,14 @@ void FurnaceGUI::drawSettings() {
             settings.saveUnusedPatterns=saveUnusedPatternsB;
           }
 
+          bool cursorFollowsOrderB=settings.cursorFollowsOrder;
+          if (ImGui::Checkbox("Cursor follows current order when moving it",&cursorFollowsOrderB)) {
+            settings.cursorFollowsOrder=cursorFollowsOrderB;
+          }
+          if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("applies when playback is stopped.");
+          }
+
           ImGui::Text("Audio export loop/fade out time:");
           if (ImGui::RadioButton("Set to these values on start-up:##fot0",settings.persistFadeOut==0)) {
             settings.persistFadeOut=0;
@@ -2609,6 +2617,7 @@ void FurnaceGUI::syncSettings() {
   settings.oneDigitEffects=e->getConfInt("oneDigitEffects",0);
   settings.disableFadeIn=e->getConfInt("disableFadeIn",0);
   settings.alwaysPlayIntro=e->getConfInt("alwaysPlayIntro",0);
+  settings.cursorFollowsOrder=e->getConfInt("cursorFollowsOrder",0);
 
   clampSetting(settings.mainFontSize,2,96);
   clampSetting(settings.patFontSize,2,96);
@@ -2932,6 +2941,7 @@ void FurnaceGUI::commitSettings() {
   e->setConf("oneDigitEffects",settings.oneDigitEffects);
   e->setConf("disableFadeIn",settings.disableFadeIn);
   e->setConf("alwaysPlayIntro",settings.alwaysPlayIntro);
+  e->setConf("cursorFollowsOrder", settings.cursorFollowsOrder);
 
   // colors
   for (int i=0; i<GUI_COLOR_MAX; i++) {


### PR DESCRIPTION
This emulates FamiTracker behavior, with the exception of moving back the orders on undo/redo ~~(because I couldn't figure it out lmao)~~

Worth noting that it can already be done, but only on playback&mdash;this enables it at pause/stop. Let me know of any problems!