### PR TITLE
Add option to prevent piano input

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -5954,6 +5954,7 @@ bool FurnaceGUI::init() {
   pianoOptions=e->getConfBool("pianoOptions",pianoOptions);
   pianoSharePosition=e->getConfBool("pianoSharePosition",pianoSharePosition);
   pianoOptionsSet=e->getConfBool("pianoOptionsSet",pianoOptionsSet);
+  pianoReadonly=e->getConfBool("pianoReadonly",false);
   pianoOffset=e->getConfInt("pianoOffset",pianoOffset);
   pianoOffsetEdit=e->getConfInt("pianoOffsetEdit",pianoOffsetEdit);
   pianoView=e->getConfInt("pianoView",pianoView);
@@ -6389,6 +6390,7 @@ void FurnaceGUI::commitState() {
   e->setConf("pianoOptions",pianoOptions);
   e->setConf("pianoSharePosition",pianoSharePosition);
   e->setConf("pianoOptionsSet",pianoOptionsSet);
+  e->setConf("pianoReadonly",pianoReadonly);
   e->setConf("pianoOffset",pianoOffset);
   e->setConf("pianoOffsetEdit",pianoOffsetEdit);
   e->setConf("pianoView",pianoView);
@@ -6835,6 +6837,7 @@ FurnaceGUI::FurnaceGUI():
   pianoOptions(true),
   pianoSharePosition(false),
   pianoOptionsSet(false),
+  pianoReadonly(false),
   pianoOffset(6),
   pianoOffsetEdit(9),
   pianoView(PIANO_LAYOUT_AUTOMATIC),
@@ -6844,6 +6847,7 @@ FurnaceGUI::FurnaceGUI():
   pianoOctavesEdit(4),
   pianoOptions(false),
   pianoSharePosition(true),
+  pianoReadonly(false),
   pianoOffset(6),
   pianoOffsetEdit(6),
   pianoView(PIANO_LAYOUT_STANDARD),

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1916,6 +1916,7 @@ class FurnaceGUI {
   bool pianoOptions, pianoSharePosition, pianoOptionsSet;
   float pianoKeyHit[180];
   bool pianoKeyPressed[180];
+  bool pianoReadonly;
   int pianoOffset, pianoOffsetEdit;
   int pianoView, pianoInputPadMode;
 

--- a/src/gui/piano.cpp
+++ b/src/gui/piano.cpp
@@ -123,6 +123,7 @@ void FurnaceGUI::drawPiano() {
             pianoInputPadMode=PIANO_INPUT_PAD_SPLIT_VISIBLE;
           }
           ImGui::Checkbox("Share play/edit offset/range",&pianoSharePosition);
+          ImGui::Checkbox("Read-only (can't input notes)",&pianoReadonly);
           ImGui::EndPopup();
         }
 
@@ -223,7 +224,7 @@ void FurnaceGUI::drawPiano() {
         //ImGui::ItemSize(size,ImGui::GetStyle().FramePadding.y);
         if (ImGui::ItemAdd(rect,ImGui::GetID("pianoDisplay"))) {
           bool canInput=false;
-          if (ImGui::ItemHoverable(rect,ImGui::GetID("pianoDisplay"))) {
+          if (!pianoReadonly && ImGui::ItemHoverable(rect,ImGui::GetID("pianoDisplay"))) {
             canInput=true;
             ImGui::InhibitInertialScroll();
           }


### PR DESCRIPTION
I hate accidentally inputting notes via the piano with the mouse and barely even noticing, only to later realize my song is riddled with random notes.

Default value is false so it won't bother anyone, I think.
This option can be toggled via the three-dot menu in the right click thingy that the piano has.