### PR TITLE
Fix pattern editor focus when selecting instrument

### DIFF
--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -287,7 +287,9 @@ void FurnaceGUI::insListItem(int i, int dir, int asset) {
   } else {
     ImGui::PushStyleColor(ImGuiCol_Text,uiColors[GUI_COLOR_TEXT]);
   }
-  if (ImGui::Selectable(name.c_str(),(i==-1)?(curIns<0 || curIns>=e->song.insLen):(curIns==i))) {
+  bool insReleased=ImGui::Selectable(name.c_str(),(i==-1)?(curIns<0 || curIns>=e->song.insLen):(curIns==i));
+  bool insPressed=ImGui::IsItemActivated();
+  if (insReleased || (!insListDir && insPressed)) {
     curIns=i;
     wavePreviewInit=true;
     updateFMPreview=true;

--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -292,11 +292,10 @@ void FurnaceGUI::insListItem(int i, int dir, int asset) {
     wavePreviewInit=true;
     updateFMPreview=true;
     lastAssetType=0;
-    if (insListDir) nextWindow=GUI_WINDOW_PATTERN;
   }
   if (wantScrollList && curIns==i) ImGui::SetScrollHereY();
   if (settings.insFocusesPattern && patternOpen && ImGui::IsItemActivated()) {
-    if (!insListDir) nextWindow=GUI_WINDOW_PATTERN;
+    nextWindow=GUI_WINDOW_PATTERN;
     curIns=i;
     wavePreviewInit=true;
     updateFMPreview=true;

--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -292,15 +292,10 @@ void FurnaceGUI::insListItem(int i, int dir, int asset) {
     wavePreviewInit=true;
     updateFMPreview=true;
     lastAssetType=0;
+    if (settings.insFocusesPattern && patternOpen)
+      nextWindow=GUI_WINDOW_PATTERN;
   }
   if (wantScrollList && curIns==i) ImGui::SetScrollHereY();
-  if (settings.insFocusesPattern && patternOpen && ImGui::IsItemActivated()) {
-    nextWindow=GUI_WINDOW_PATTERN;
-    curIns=i;
-    wavePreviewInit=true;
-    updateFMPreview=true;
-    lastAssetType=0;
-  }
   if (ImGui::IsItemHovered() && i>=0 && !mobileUI) {
     ImGui::PushStyleColor(ImGuiCol_Text,uiColors[GUI_COLOR_TEXT]);
     ImGui::SetTooltip("%s",insType);


### PR DESCRIPTION
Currently, upon selecting an instrument with folder mode enabled, the "Pattern" window is focused, even if the `Focus pattern editor when selecting instrument` option is off. This small PR attempts to fix that.

(Issue previously mentioned [on discord](https://discord.com/channels/936515318220722197/941448809777627136/1109628962562387999))