### PR TITLE
ZSM export: suppress the extra tick before the loop

### DIFF
--- a/src/engine/zsmOps.cpp
+++ b/src/engine/zsmOps.cpp
@@ -160,7 +160,7 @@ SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop) {
     fracWait+=cycles&MASTER_CLOCK_MASK;
     totalWait+=fracWait>>MASTER_CLOCK_PREC;
     fracWait&=MASTER_CLOCK_MASK;
-    if (totalWait>0) {
+    if (totalWait>0 && !done) {
       zsm.tick(totalWait);
       //tickCount+=totalWait;
     }


### PR DESCRIPTION
This trivially solves the problem of an extra tick being present in the loop of all exported ZSMs.  This does, however, include the register writes that happen at the loop point.  I think a rethink of the export might be in the future due to the problem explained below:

Writes that are suppressed by Furnace's `getRegisterWrites` on the first loop, such as extra key off events , are not exported during the first loop but are actually relevant after looping if a note is held through the loop.

My reading of VGM export looks like it does this:
```
preamble -> module loop point -> music -> return to loop (VGM loop point here) -> music -> VGM loop point marker
```

So the export of VGM ends up writing two passes of the looped section, which ensures all of the writes are correct, but it results in more data written.

Since ZSM is meant for playback on a real 8-bit system -- the Commander X16, the extra loop being exported could be substantial in size, so I think the status quo is fine for now.

Closes #1058 