### PR TITLE
ZSM export: Update format, implement PCM export support

### DIFF
--- a/papers/zsm-format.md
+++ b/papers/zsm-format.md
@@ -2,9 +2,11 @@
 
 #### Zsound Repo
 
-ZSM is part of the Zsound suite of Commander X16 audio tools found at:</br>
+ZSM is part of the Zsound suite of Commander X16 audio tools found at:  
 https://github.com/ZeroByteOrg/zsound/
 
+An alternative library with PCM support, ZSMKit, is avalable at:  
+https://github.com/mooinglemur/ZSMKit
 
 #### Current ZSM Revision: 1
 
@@ -69,14 +71,35 @@ The EXTCMD byte is formatted as `ccnnnnnn` where `c`=channel and `n`=number of b
 
 ### PCM Header
 
-The size and contents of the PCM header table is not yet decided. This will depend largely on the strucure of EXTCMD channel 0, and be covered in detail in that specification.
+If the PCM header exists in the ZSM file, it will immediately follow the 0x80 end-of-data marker. The PCM header exists only if at least one PCM instrument exists.
 
-Any offset values contained in the PCM data header block will be relative to the beginning of the PCM header, not the ZSM header. The intention is to present the digital audio portion as a set of digi clips ("samples" in tracker terminology) whose playback can be triggered by EXTCMD channel zero.
+Since each instrument defined is 16 bytes, the size of the PCM header can be calculated
+as 4+(16*(last_instrument_index+1)).
+
+Offset|Type|Value
+--|--|--
+0x00-0x02|String|"PCM"
+0x03|Byte|The last PCM instrument index
+0x04-0x13|Mixed|Instrument definition for instrument 0x00
+0x14-0x23|Mixed|(optional) Instrument definition for instrument 0x01
+...
+
+### Instrument definition
+Offset|Type|Value
+--|--|--
+0x00|Byte|This instrument's index
+0x01|Bitmask|AUDIO_CTRL: 00**DC**0000: D is set for 16-bit, and clear for 8-bit. C is set for stereo and clear for mono
+0x02-0x04|24-bit int|Little-endian offset into the PCM data block
+0x05-0x07|24-bit int|Little-endian length of PCM data
+0x08|Bitmask|Features: **L**xxxxxxx: L is set if the sample is looped
+0x09-0x0b|24-bit int|Little-endian loop point offset (relative, 0 is the beginning of this instrument's sample)
+0x0c-0x0f|...|Reserved for expansion
+
+Any offset values contained in the PCM data header block are relative to the beginning of the PCM sample data section, not to the PCM header or ZSM header. The intention is to present the digital audio portion as a set of digi clips ("samples" in tracker terminology) whose playback can be triggered by EXTCMD channel zero.
 
 ### PCM Sample Data
 
-This will be a blob of PCM data with no internal formatting. Indeces / format information / loop points / etc regarding this blob will be provided via the PCM header. The end of this blob will be the end of the ZSM file.
-
+This is blob of PCM data with no internal formatting. Offsets into this blob are provided via the PCM header. The end of this blob will be the end of the ZSM file.
 
 ## EXTCMD Channel Scifications
 
@@ -108,7 +131,13 @@ The Custom channel data may take whatever format is desired for any particular p
 ### EXTCMD Channel:
 #### 0: PCM audio
 
-The structure of data within this channel is not yet defined.
+This EXTCMD stream can contain one or more command + argument pairs.
+
+command|meaning|argument|description
+---|---|---|---
+0x00|AUDIO_CTRL byte|byte|This byte sets PCM channel volume and/or clears the FIFO
+0x01|AUDIO_RATE byte|byte|A value from 0x00-0x80 to set the sample rate (playback speed)
+0x02|Instrument trigger|byte|Triggers the PCM instrument specified by this byte index
 
 #### 1: Expansion Sound Devices
 

--- a/src/engine/zsm.cpp
+++ b/src/engine/zsm.cpp
@@ -53,9 +53,17 @@ void DivZSM::init(unsigned int rate) {
   tickRate=rate;
   loopOffset=-1;
   numWrites=0;
+  ticks=0;
+  // Initialize YM/PSG states
   memset(&ymState,-1,sizeof(ymState));
   memset(&psgState,-1,sizeof(psgState));
-  ticks=0;
+  // Initialize PCM states
+  pcmRateCache=-1;
+  pcmCtrlRVCache=-1;
+  pcmCtrlDCCache=-1;
+  // Channel masks
+  ymMask=0;
+  psgMask=0;
 }
 
 int DivZSM::getoffset() {

--- a/src/engine/zsm.h
+++ b/src/engine/zsm.h
@@ -38,16 +38,26 @@ enum PSG_STATE { psg_PREV, psg_NEW, psg_STATES };
 
 class DivZSM {
   private:
+    typedef struct {
+      int geometry, offset, length;
+    } S_pcmInst;
     SafeWriter* w;
     int ymState[ym_STATES][256];
     int psgState[psg_STATES][64];
+    int pcmRateCache=-1;
+    int pcmCtrlRVCache=-1;
+    int pcmCtrlDCCache=-1;
     std::vector<DivRegWrite> ymwrites;
+    std::vector<DivRegWrite> pcmMeta;
+    std::vector<unsigned char> pcmData;
+    std::vector<unsigned char> pcmCache;
+    std::vector<S_pcmInst> pcmInsts;
     int loopOffset;
     int numWrites;
     int ticks;
     int tickRate;
-  int ymMask = 0;
-  int psgMask = 0;
+    int ymMask=0;
+    int psgMask=0;
   public:
     DivZSM();
     ~DivZSM();

--- a/src/engine/zsm.h
+++ b/src/engine/zsm.h
@@ -38,15 +38,15 @@ enum PSG_STATE { psg_PREV, psg_NEW, psg_STATES };
 
 class DivZSM {
   private:
-    typedef struct {
+    struct S_pcmInst {
       int geometry, offset, length;
-    } S_pcmInst;
+    };
     SafeWriter* w;
     int ymState[ym_STATES][256];
     int psgState[psg_STATES][64];
-    int pcmRateCache=-1;
-    int pcmCtrlRVCache=-1;
-    int pcmCtrlDCCache=-1;
+    int pcmRateCache;
+    int pcmCtrlRVCache;
+    int pcmCtrlDCCache;
     std::vector<DivRegWrite> ymwrites;
     std::vector<DivRegWrite> pcmMeta;
     std::vector<unsigned char> pcmData;
@@ -56,8 +56,8 @@ class DivZSM {
     int numWrites;
     int ticks;
     int tickRate;
-    int ymMask=0;
-    int psgMask=0;
+    int ymMask;
+    int psgMask;
   public:
     DivZSM();
     ~DivZSM();

--- a/src/engine/zsmOps.cpp
+++ b/src/engine/zsmOps.cpp
@@ -150,7 +150,10 @@ SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop) {
         logD("zsmOps: Writing %d messages to chip %d",writes.size(),i);
       for (DivRegWrite& write: writes) {
         if (i==YM) zsm.writeYM(write.addr&0xff,write.val);
-        if (i==VERA) zsm.writePSG(write.addr&0xff,write.val);
+        if (i==VERA) {
+          if (done && write.addr >= 64) continue; // don't process any PCM events on the loop lookahead
+          zsm.writePSG(write.addr&0xff,write.val);
+        }
       }
       writes.clear();
     }

--- a/src/engine/zsmOps.cpp
+++ b/src/engine/zsmOps.cpp
@@ -160,7 +160,7 @@ SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop) {
     fracWait+=cycles&MASTER_CLOCK_MASK;
     totalWait+=fracWait>>MASTER_CLOCK_PREC;
     fracWait&=MASTER_CLOCK_MASK;
-    if (totalWait>0) {
+    if (totalWait>0 && !done) {
       zsm.tick(totalWait);
       //tickCount+=totalWait;
     }


### PR DESCRIPTION
Since ZeroByte has not been active in the X16 community for almost a half year, ZSM/ZSound development has stalled.  We chatted briefly a couple months ago and while I didn't tell him I was planning to do this, I don't think he'd be upset by my design choices. In fact, I was not planning on doing this, but we've had a few questions in the Commander X16 community recently about getting music playback on the system with the PCM channel.

This PR adds support for the ZSM export feature in Furnace to include PCM data in the output.  These ZSMs are compatible with existing players prior to this format change but, of course, those will not play the PCM notes.  They are already aware of EXTDATA blocks and will simply skip over them. (Tested with Calliope)

C++ is definitely not my strongest language, but I have a pretty solid C foundation.  Please feel free to ask for changes on that basis. This is the most C++ I've ever done. :)

This PR includes the change from #1185 so if you choose to accept this one first, you can ignore/close that one and its associated issue.  Feel free to reach out on Discord if you have questions.