### PR TITLE
ZSM export: support for looped samples, fix error dispatching ZSM sync events

### DIFF
--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -915,7 +915,7 @@ void DivEngine::processRow(int i, bool afterDelay) {
         //printf("\x1b[1;36m%d: extern command %d\x1b[m\n",i,effectVal);
         extValue=effectVal;
         extValuePresent=true;
-        dispatchCmd(DivCommand(DIV_CMD_EXTERNAL,effectVal));
+        dispatchCmd(DivCommand(DIV_CMD_EXTERNAL,i,effectVal));
         break;
       case 0xef: // global pitch
         globalPitch+=(signed char)(effectVal-0x80);

--- a/src/engine/zsm.h
+++ b/src/engine/zsm.h
@@ -46,7 +46,9 @@ enum PSG_STATE { psg_PREV, psg_NEW, psg_STATES };
 class DivZSM {
   private:
     struct S_pcmInst {
-      int geometry, offset, length;
+      int geometry;
+      unsigned int offset, length, loopPoint;
+      bool isLooped;
     };
     SafeWriter* w;
     int ymState[ym_STATES][256];
@@ -54,6 +56,8 @@ class DivZSM {
     int pcmRateCache;
     int pcmCtrlRVCache;
     int pcmCtrlDCCache;
+    unsigned int pcmLoopPointCache;
+    bool pcmIsLooped;
     std::vector<DivRegWrite> ymwrites;
     std::vector<DivRegWrite> pcmMeta;
     std::vector<unsigned char> pcmData;


### PR DESCRIPTION
This change informs ZSM export on VERA to indicate the next sample data to come through has a loop point.

It also fixes sync events.