### PR TITLE
ZSM export: fix two bugs w/ looped sample export

### DIFF
--- a/src/engine/platform/vera.cpp
+++ b/src/engine/platform/vera.cpp
@@ -236,9 +236,12 @@ void DivPlatformVERA::tick(bool sysTick) {
     if (s->samples>0) {
       if (s->isLoopable()) {
         // Inform the export process of the loop point for this sample
-        addWrite(67,s->loopStart&0xff);
-        addWrite(67,(s->loopStart>>8)&0xff);
-        addWrite(67,(s->loopStart>>16)&0xff);
+        int tmp_ls=(s->loopStart<<1); // for stereo
+        if (chan[16].pcm.depth16)
+          tmp_ls<<=1; // for 16 bit
+        addWrite(67,tmp_ls&0xff);
+        addWrite(67,(tmp_ls>>8)&0xff);
+        addWrite(67,(tmp_ls>>16)&0xff);
       }
       while (true) {
         short tmp_l=0;

--- a/src/engine/zsm.cpp
+++ b/src/engine/zsm.cpp
@@ -318,6 +318,7 @@ void DivZSM::flushWrites() {
             }
             pcmCache.resize(pcmCache.size()>>1);
             pcmCtrlDCCache&=(unsigned char)~0x10; // clear stereo bit
+            pcmLoopPointCache>>=1; // halve the loop point
           }
         }
       } else { // 8-bit
@@ -334,6 +335,7 @@ void DivZSM::flushWrites() {
             }
             pcmCache.resize(pcmCache.size()>>1);
             pcmCtrlDCCache&=(unsigned char)~0x10; // clear stereo bit
+            pcmLoopPointCache>>=1; // halve the loop point
           }
         }
       }
@@ -365,9 +367,9 @@ void DivZSM::flushWrites() {
       inst.loopPoint=pcmLoopPointCache;
       inst.isLooped=pcmIsLooped;
       pcmInsts.push_back(inst);
-      pcmIsLooped=false;
-      pcmLoopPointCache=0;
     }
+    pcmIsLooped=false;
+    pcmLoopPointCache=0;
   }
   if (extCmd0Len>63) { // this would be bad, but will almost certainly never happen
     logE("ZSM: extCmd 0 exceeded maximum length of 63: %d",extCmd0Len);


### PR DESCRIPTION
Previously. loop point was accidentally correct for center-panned 8-bit channels.  Now it should be correct for all.

Loop point cache was not properly reset after matching a previous instance of the sample, hence some instruments were getting loop points when they should not have been.