### PR TITLE
Systems docs reorganized into chips. (demo)

### DIFF
--- a/doc/7-chips/README.md
+++ b/doc/7-chips/README.md
@@ -1,0 +1,10 @@
+# systems
+
+- **Commodore Amiga**:     [Paula / MOS 8364 R4](paula.md)
+- **Nintendo Game Boy**:   [Sharp LR35902](gb.md)
+- **Nintendo NES**:        [Ricoh 2A03 / 2A07](nes.md)
+- **Sega CD**:             [Yamaha YM2612](ym2612.md), [Sega PSG](sn7.md), [Ricoh RF5C68](rf5c68.md)
+- **Sega Genesis**:        [Yamaha YM2612](ym2612.md), [Sega PSG](sn7.md)
+- **Sega Master System**:  [Sega PSG](sn7.md)
+- **TI-99/4A**:            [TI TMS9919 / TI SN94624](sn7.md)
+

--- a/doc/7-chips/gb.md
+++ b/doc/7-chips/gb.md
@@ -1,0 +1,31 @@
+# Sharp LR35902 (GB APU)
+
+this chip was custom-made for the Nintendo Game Boy, one of the most successful portable game systems ever made.
+
+with stereo sound, two pulse channels, a wave channel and a noise channel, it packed some serious punch.
+
+this chip accepts [Game Boy](../4-instrument/game-boy.md) instruments and 32x16 wavetables.
+
+
+# effects
+
+- `10xx`: **change wave.**
+- `11xx`: **set noise length.**
+  - `0`: long
+  - `1`: short
+- `12xx`: **set duty cycle.**
+  - `0`: 12.5%
+  - `1`: 25%
+  - `2`: 50%
+  - `3`: 75%
+- `13xy`: **setup sweep.** pulse channels only.
+  - `x` is the time.
+  - `y` is the shift.
+  - set to `0` to disable it.
+- `14xx`: **set sweep direction.** `0` is up and `1` is down.
+
+# links
+
+- [Gameboy sound hardware](https://gbdev.gg8.se/wiki/articles/Gameboy_sound_hardware) - detailed technical information
+
+- [GameBoy Sound Table](http://www.devrs.com/gb/files/sndtab.html) - note frequency table

--- a/doc/7-chips/nes.md
+++ b/doc/7-chips/nes.md
@@ -1,0 +1,184 @@
+# Ricoh 2A03 / 2A07 (NES APU)
+
+this APU is part of the heart of the console from Nintendo that plays Super Mario Bros. and helped revive the agonizing video game market in the US during mid-80s.
+
+also known as Famicom. it is a five-channel sound generator: first two channels play pulse wave with three different duty cycles, third is a fixed-volume triangle channel, fourth is a noise channel (can work in both pseudo-random and periodic modes) and fifth is a (D)PCM sample channel.
+
+this chip accepts [NES](../4-instrument/nes.md) and [Generic Sample](../4-instruments/sample.md) instruments.
+
+
+# effects
+
+- `11xx`: **write to delta modulation counter.** range is `00` to `7F`.
+  - this may be used to attenuate the triangle and noise channels; at `7F`, they will be at about 57% volume.
+  - will not work if a sample is playing.
+- `12xx`: **set duty cycle or noise mode of channel.**
+  - may be `0` to `3` for the pulse channels:
+    - `0`: 12.5%
+    - `1`: 25%
+    - `2`: 50%
+    - `3`: 75%
+  - may be `0` or `1` for the noise channel:
+    - `0`: long (15-bit LFSR, 32767-step)
+    - `1`: short (9-bit LFSR, 93-step)
+- `13xy`: **setup sweep up.**
+  - `x` is the time.
+  - `y` is the shift.
+  - set to `0` to disable it.
+- `14xy`: **setup sweep down.**
+  - `x` is the time.
+  - `y` is the shift.
+  - set to `0` to disable it.
+- `15xx`: **set envelope mode.**
+  - `0`: envelope + length counter. volume represents envelope duration.
+  - `1`: length counter. volume represents output volume.
+  - `2`: looping envelope. volume represents envelope duration.
+  - `3`: constant volume. default value. volume represents output volume.
+  - Pulse and noise channels only.
+  - you may need to apply a phase reset (using the macro) to make the envelope effective.
+- `16xx`: **set length counter.**
+  - see table below for possible values.
+  - this will trigger phase reset.
+- `17xx`: **set frame counter mode.**
+  - `0`: 4-step.
+    - NTSC: 120Hz sweeps and lengths; 240Hz envelope.
+    - PAL: 100Hz sweeps and lengths; 200Hz envelope.
+    - Dendy: 118.9Hz sweeps and lengths; 237.8Hz envelope.
+  - `1`: 5-step.
+    - NTSC: 96Hz sweeps and lengths; 192Hz envelope.
+    - PAL: 80Hz sweeps and lengths; 160Hz envelope.
+    - Dendy: 95.1Hz sweeps and lengths; 190.2Hz envelope.
+- `18xx`: **set PCM channel mode.**
+  - `00`: PCM (software).
+  - `01`: DPCM (hardware).
+  - when in DPCM mode, samples will sound muffled (due to its nature), availables pitches are limited, and loop point is ignored.
+- `19xx`: **set triangle linear counter.**
+  - `00` to `7F` set the counter.
+  - `80` and higher halt it.
+- `20xx`: **set DPCM frequency.**
+  - only works in DPCM mode.
+  - see table below for possible values.
+
+# tables
+
+## short noise frequencies (NTSC)
+
+note  | arpeggio | fundamental | MIDI note | pitch
+:---- | -------: | ----------: | --------: | :----------
+`C-0` |       @0 |      4.7 Hz |     -9.47 | `d_1` + 53¢ 
+`C#0` |       @1 |      9.5 Hz |      2.53 | `D-0` + 53¢
+`D-0` |       @2 |     18.9 Hz |     14.55 | `D-1` + 55¢
+`D#0` |       @3 |     25.3 Hz |     19.53 | `G-1` + 53¢
+`E-0` |       @4 |     37.9 Hz |     26.55 | `D-2` + 55¢
+`F-0` |       @5 |     50.6 Hz |     31.57 | `G-2` + 57¢
+`F#0` |       @6 |     75.8 Hz |     38.55 | `D-3` + 55¢
+`G-0` |       @7 |     95.3 Hz |     42.51 | `F#3` + 51¢
+`G#0` |       @8 |    120.3 Hz |     46.55 | `A#3` + 55¢
+`A-0` |       @9 |    150.4 Hz |     50.41 | `D-4` + 41¢
+`A#0` |      @10 |    200.5 Hz |     55.39 | `G-4` + 39¢
+`B-0` |      @11 |    300.7 Hz |     62.41 | `D-5` + 41¢
+`C-1` |      @12 |    601.4 Hz |     74.41 | `D-6` + 41¢
+`C#1` |      @13 |   1202.8 Hz |     86.41 | `D-7` + 41¢
+`D-1` |      @14 |   2405.6 Hz |     98.41 | `D-8` + 41¢
+`D#1` |      @15 |   4811.2 Hz |    110.41 | `D-9` + 41¢
+
+reference: [NESdev](https://www.nesdev.org/wiki/APU_Noise)
+
+## length counter table
+
+<!-- organized by input value... of little use -->
+<!--
+value | raw | NTSC  | PAL   | Dendy | NTSC 5-step | PAL 5-step | Dendy 5-step
+-----:|----:|------:|------:|------:|------------:|-----------:|-------------:
+ `00` |  10 | 83ms  | 100ms | 84ms  | 104ms       | 125ms      | 105ms
+ `01` | 254 | 2.1s  | 2.5s  | 2.1s  | 2.6s        | 3.2s       | 2.7s
+ `02` |  20 | 166ms | 200ms | 168ms | 208ms       | 250ms      | 210ms
+ `03` |   2 | 17ms  | 20ms  | 17ms  | 21ms        | 25ms       | 21ms
+ `04` |  40 | 333ms | 400ms | 336ms | 417ms       | 500ms      | 421ms
+ `05` |   4 | 33ms  | 40ms  | 34ms  | 42ms        | 50ms       | 42ms
+ `06` |  80 | 667ms | 800ms | 673ms | 833ms       | 1.0s       | 841ms
+ `07` |   6 | 50ms  | 60ms  | 50ms  | 63ms        | 75ms       | 63ms
+ `08` | 160 | 1.3s  | 1.6s  | 1.3s  | 1.7s        | 2.0s       | 1.7s
+ `09` |   8 | 67ms  | 80ms  | 67ms  | 83ms        | 100ms      | 84ms
+ `0A` |  60 | 500ms | 600ms | 505ms | 625ms       | 750ms      | 631ms
+ `0B` |  10 | 83ms  | 100ms | 84ms  | 104ms       | 125ms      | 105ms
+ `0C` |  14 | 117ms | 140ms | 118ms | 146ms       | 175ms      | 147ms
+ `0D` |  12 | 100ms | 120ms | 101ms | 125ms       | 150ms      | 126ms
+ `0E` |  26 | 217ms | 260ms | 219ms | 271ms       | 325ms      | 273ms
+ `0F` |  14 | 117ms | 140ms | 118ms | 145ms       | 175ms      | 147ms
+ `10` |  12 | 100ms | 120ms | 101ms | 125ms       | 150ms      | 126ms
+ `11` |  16 | 133ms | 160ms | 135ms | 167ms       | 200ms      | 168ms
+ `12` |  24 | 200ms | 240ms | 202ms | 250ms       | 300ms      | 252ms
+ `13` |  18 | 150ms | 180ms | 151ms | 188ms       | 225ms      | 189ms
+ `14` |  48 | 400ms | 480ms | 404ms | 500ms       | 600ms      | 505ms
+ `15` |  20 | 167ms | 200ms | 168ms | 208ms       | 250ms      | 210ms
+ `16` |  96 | 800ms | 960ms | 807ms | 1.0s        | 1.2s       | 1.0s
+ `17` |  22 | 183ms | 220ms | 185ms | 229ms       | 275ms      | 231ms
+ `18` | 192 | 1.6s  | 1.9s  | 1.6s  | 2.0s        | 2.4s       | 2.0s
+ `19` |  24 | 200ms | 240ms | 202ms | 250ms       | 300ms      | 252ms
+ `1A` |  72 | 600ms | 720ms | 606ms | 750ms       | 900ms      | 757ms
+ `1B` |  26 | 217ms | 260ms | 219ms | 271ms       | 325ms      | 273ms
+ `1C` |  16 | 133ms | 160ms | 135ms | 167ms       | 200ms      | 168ms
+ `1D` |  28 | 233ms | 280ms | 235ms | 292ms       | 350ms      | 294ms
+ `1E` |  32 | 267ms | 320ms | 269ms | 333ms       | 400ms      | 336ms
+ `1F` |  30 | 250ms | 300ms | 252ms | 313ms       | 375ms      | 315ms
+-->
+
+<!-- organized by resulting times... more useful! -->
+value | raw | NTSC  | PAL   | Dendy | NTSC 5-step | PAL 5-step | Dendy 5-step
+-----:|----:|------:|------:|------:|------------:|-----------:|-------------:
+ `03` |   2 | 17ms  | 20ms  | 17ms  | 21ms        | 25ms       | 21ms
+ `05` |   4 | 33ms  | 40ms  | 34ms  | 42ms        | 50ms       | 42ms
+ `07` |   6 | 50ms  | 60ms  | 50ms  | 63ms        | 75ms       | 63ms
+ `09` |   8 | 67ms  | 80ms  | 67ms  | 83ms        | 100ms      | 84ms
+ `00` |  10 | 83ms  | 100ms | 84ms  | 104ms       | 125ms      | 105ms
+ `0B` |  10 | 83ms  | 100ms | 84ms  | 104ms       | 125ms      | 105ms
+ `0D` |  12 | 100ms | 120ms | 101ms | 125ms       | 150ms      | 126ms
+ `10` |  12 | 100ms | 120ms | 101ms | 125ms       | 150ms      | 126ms
+ `0C` |  14 | 117ms | 140ms | 118ms | 146ms       | 175ms      | 147ms
+ `0F` |  14 | 117ms | 140ms | 118ms | 145ms       | 175ms      | 147ms
+ `1C` |  16 | 133ms | 160ms | 135ms | 167ms       | 200ms      | 168ms
+ `11` |  16 | 133ms | 160ms | 135ms | 167ms       | 200ms      | 168ms
+ `13` |  18 | 150ms | 180ms | 151ms | 188ms       | 225ms      | 189ms
+ `02` |  20 | 166ms | 200ms | 168ms | 208ms       | 250ms      | 210ms
+ `15` |  20 | 167ms | 200ms | 168ms | 208ms       | 250ms      | 210ms
+ `17` |  22 | 183ms | 220ms | 185ms | 229ms       | 275ms      | 231ms
+ `12` |  24 | 200ms | 240ms | 202ms | 250ms       | 300ms      | 252ms
+ `19` |  24 | 200ms | 240ms | 202ms | 250ms       | 300ms      | 252ms
+ `0E` |  26 | 217ms | 260ms | 219ms | 271ms       | 325ms      | 273ms
+ `1B` |  26 | 217ms | 260ms | 219ms | 271ms       | 325ms      | 273ms
+ `1D` |  28 | 233ms | 280ms | 235ms | 292ms       | 350ms      | 294ms
+ `1F` |  30 | 250ms | 300ms | 252ms | 313ms       | 375ms      | 315ms
+ `1E` |  32 | 267ms | 320ms | 269ms | 333ms       | 400ms      | 336ms
+ `04` |  40 | 333ms | 400ms | 336ms | 417ms       | 500ms      | 421ms
+ `14` |  48 | 400ms | 480ms | 404ms | 500ms       | 600ms      | 505ms
+ `0A` |  60 | 500ms | 600ms | 505ms | 625ms       | 750ms      | 631ms
+ `1A` |  72 | 600ms | 720ms | 606ms | 750ms       | 900ms      | 757ms
+ `06` |  80 | 667ms | 800ms | 673ms | 833ms       | 1.0s       | 841ms
+ `16` |  96 | 800ms | 960ms | 807ms | 1.0s        | 1.2s       | 1.0s
+ `08` | 160 | 1.3s  | 1.6s  | 1.3s  | 1.7s        | 2.0s       | 1.7s
+ `18` | 192 | 1.6s  | 1.9s  | 1.6s  | 2.0s        | 2.4s       | 2.0s
+ `01` | 254 | 2.1s  | 2.5s  | 2.1s  | 2.6s        | 3.2s       | 2.7s
+
+reference: [NESdev](https://www.nesdev.org/wiki/APU_Length_Counter)
+
+## DPCM frequency table
+
+value | NTSC      | PAL
+------|----------:|----------:
+ `00` | 4181.7Hz  | 4177.4Hz
+ `01` | 4709.9Hz  | 4696.6Hz
+ `02` | 5264.0Hz  | 5261.4Hz
+ `03` | 5593.0Hz  | 5579.2Hz
+ `04` | 6257.9Hz  | 6023.9Hz
+ `05` | 7046.3Hz  | 7044.9Hz
+ `06` | 7919.3Hz  | 7917.2Hz
+ `07` | 8363.4Hz  | 8397.0Hz
+ `08` | 9419.9Hz  | 9446.6Hz
+ `09` | 11186.1Hz | 11233.8Hz
+ `0A` | 12604.0Hz | 12595.5Hz
+ `0B` | 13982.6Hz | 14089.9Hz
+ `0C` | 16884.6Hz | 16965.4Hz
+ `0D` | 21306.8Hz | 21315.5Hz
+ `0E` | 24858.0Hz | 25191.0Hz
+ `0F` | 33143.9Hz | 33252.1Hz

--- a/doc/7-chips/paula.md
+++ b/doc/7-chips/paula.md
@@ -1,0 +1,20 @@
+# MOS 8364 R4 "Paula"
+
+custom-made for the commodore amiga, a computer with a desktop OS, lifelike graphics and 4 channels of PCM sound... in 1985!
+
+it's for this chip that music trackers were born...
+
+imported MOD files use this chip, and will set A-4 tuning to 436.
+
+this chip accepts [Generic Sample](../4-instrument/sample.md) instruments.
+
+
+# effects
+
+- `10xx`: **toggle low-pass filter.** `0` turns it off and `1` turns it on.
+- `11xx`: **toggle amplitude modulation with the next channel.**
+  - does not work on the last channel.
+- `12xx`: **toggle period (frequency) modulation with the next channel.**
+  - does not work on the last channel.
+- `13xx`: **change wave.**
+  - only works when "Mode" is set to "Wavetable" in the instrument.

--- a/doc/7-chips/rf5c68.md
+++ b/doc/7-chips/rf5c68.md
@@ -1,0 +1,10 @@
+# Ricoh RF5C68
+
+YM2612's sidekick - poor man's SNES DSP. 8-channel PCM sample-based synthesizer used in Sega CD, Fujitsu FM Towns and some of Sega's arcade machines. supports up to 64KB of external PCM data.
+
+this chip accepts [Generic Sample](../4-instrument/sample.md) instruments.
+
+# effects
+
+none so far.
+

--- a/doc/7-chips/sn7.md
+++ b/doc/7-chips/sn7.md
@@ -1,0 +1,17 @@
+# TI SN76489 and derivatives
+
+a relatively simple sound chip made by Texas Instruments. it has many versions, and a derivative of it is used in Sega's Master System, the predecessor to Genesis.
+
+the original iteration of the SN76489 used in the TI-99/4A computer, the SN94624, could only produce tones as low as 100Hz, and was clocked at 447 KHz. all later versions (such as the one in the Master System and Genesis) had a clock divider but ran on a faster clock... except for the SN76494, which can play notes as low as 13.670 Hz (A -1). consequently, its pitch accuracy for higher notes is compromised.
+
+this chip accepts [SN76489/Sega PSG](../4-instrument/standard.md) instruments.
+
+# effects
+
+- `20xy`: **set noise mode.**
+  - `x` controls whether to inherit frequency from channel 3.
+    - `0`: use one of 3 preset frequencies (C: A-2; C#: A-3; D: A-4).
+    - `1`: use frequency of channel 3.
+  - `y` controls whether to select noise or thin pulse.
+    - `0`: thin pulse.
+    - `1`: noise.

--- a/doc/7-chips/ym2612.md
+++ b/doc/7-chips/ym2612.md
@@ -1,0 +1,88 @@
+# Yamaha YM2612
+
+one of two chips that powered the Sega Genesis. it is a six-channel, four-operator FM synthesizer. channel #6 can be turned into 8-bit PCM player, that via software mixing, thanks to Z80 sound CPU, can play more than one channel of straight-shot samples at once. as of Furnace 0.6pre5, Furnace offers DualPCM, which allows 2 channels of software-mixed 8-bit PCM samples at 13750 Hz.
+
+this chip accepts [FM (OPN)](../4-instrument/fm.md) and [Generic Sample](../4-instruments/sample.md) instruments.
+
+# effects
+
+- `10xy`: **set LFO parameters.**
+  - `x` toggles the LFO.
+  - `y` sets its speed.
+- `11xx`: **set feedback of channel.**
+- `12xx`: **set operator 1 level.**
+- `13xx`: **set operator 2 level.**
+- `14xx`: **set operator 3 level.**
+- `15xx`: **set operator 4 level.**
+- `16xy`: **set multiplier of operator.**
+  - `x` is the operator (1-4).
+  - `y` is the multiplier.
+- `17xx`: **enable PCM channel.**
+  - this only works on channel 6.
+  - _this effect is here for compatibility reasons!_ it is otherwise recommended to use Sample type instruments (which automatically enable PCM mode when used).
+- `18xx`: **toggle extended channel 3 mode.**
+  - 0 disables it and 1 enables it.
+  - only in extended channel 3 chip.
+- `19xx`: **set attack of all operators.**
+- `1Axx`: **set attack of operator 1.**
+- `1Bxx`: **set attack of operator 2.**
+- `1Cxx`: **set attack of operator 3.**
+- `1Dxx`: **set attack of operator 4.**
+- `30xx`: **enable envelope hard reset.**
+  - this works by inserting a quick release and tiny delay before a new note.
+- `50xy`: **set AM of operator.**
+  - `x` is the operator (1-4). a value of 0 means "all operators".
+  - `y` determines whether AM is on.
+- `51xy`: **set SL of operator.**
+  - `x` is the operator (1-4). a value of 0 means "all operators".
+  - `y` is the value.
+- `52xy`: **set RR of operator.**
+  - `x` is the operator (1-4). a value of 0 means "all operators".
+  - `y` is the value.
+- `53xy`: **set DT of operator.**
+  - `x` is the operator (1-4). a value of 0 means "all operators".
+  - `y` is the value:
+    - `0`: -3
+    - `1`: -2
+    - `2`: -1
+    - `3`: 0
+    - `4`: 1
+    - `5`: 2
+    - `6`: 3
+    - `7`: -0
+- `54xy`: **set RS of operator.**
+  - `x` is the operator (1-4). a value of 0 means "all operators".
+  - `y` is the value.
+- `55xy`: **set SSG-EG of operator.**
+  - `x` is the operator (1-4). a value of 0 means "all operators".
+  - `y` is the value (0-8).
+    - values between 0 and 7 set SSG-EG.
+    - value 8 disables it.
+- `56xx`: **set DR of all operators.**
+- `57xx`: **set DR of operator 1.**
+- `58xx`: **set DR of operator 2.**
+- `59xx`: **set DR of operator 3.**
+- `5Axx`: **set DR of operator 4.**
+- `5Bxx`: **set D2R/SR of all operators.**
+- `5Cxx`: **set D2R/SR of operator 1.**
+- `5Dxx`: **set D2R/SR of operator 2.**
+- `5Exx`: **set D2R/SR of operator 3.**
+- `5Fxx`: **set D2R/SR of operator 4.**
+
+# modes
+
+## extended channel 3
+
+in ExtCh mode, channel 3 is split into one column for each of its four operators. feedback and LFO levels are shared. the frequency of each operator may be controlled independently with notes and effects. this can be used for more polyphony or more complex sounds.
+
+all four operators are still combined according to the algorithm in use. for example, algorithm 7 acts as four independent sine waves. algorithm 4 acts as two independent 2op sounds. even with algorithm 0, placing a note in any operator triggers that operator alone.
+
+## CSM
+
+CSM is short for "Composite Sinusoidal Modeling". CSM works by sending key-on and key-off commands to channel 3 at a specific frequency, controlled by the added "CSM Timer" channel. this can be used to create vocal formants (speech synthesis!) or other complex effects.
+
+CSM is beyond the scope of this documentation. for more information, see this [brief SSG-EG and CSM video tutorial](https://www.youtube.com/watch?v=IKOR0TUlnWU).
+
+## DualPCM
+
+DualPCM splits channel 6 into two individual PCM channels. using the console's Z80 processor, these are mixed together in software and streamed to channel 6 in PCM mode. because this generates a stream of data, exported VGM files will be very large.


### PR DESCRIPTION
Just a demo of how it might look. Chip pages have links to their instrument types.

If there are systems that have special quirks outside of just their chips, we could make separate pages for those in (what's presently named) 7-systems, but I couldn't think of any.

<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->
