### PR TITLE
Add percent sign to "scale" in replace dialog.

### DIFF
--- a/src/gui/findReplace.cpp
+++ b/src/gui/findReplace.cpp
@@ -39,7 +39,7 @@ const char* queryReplaceModes[GUI_QUERY_REPLACE_MAX]={
   "set",
   "add",
   "add (overflow)",
-  "scale",
+  "scale %",
   "clear"
 };
 


### PR DESCRIPTION
It's not clear that the "scale" option in the find/replace dialog takes a percentage. This'll fix that!