### PR TITLE
Rename "AdLib/Sound Blaster (drums mode" to Sound Blaster

### DIFF
--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -991,7 +991,7 @@ void FurnaceGUI::initSystemPresets() {
     }
   );
   ENTRY(
-    "PC + AdLib/Sound Blaster (drums mode)", {
+    "PC + Sound Blaster (drums mode)", {
       CH(DIV_SYSTEM_OPL2_DRUMS, 1.0f, 0, ""),
       CH(DIV_SYSTEM_PCSPKR, 1.0f, 0, ""),
       CH(DIV_SYSTEM_PCM_DAC, 1.0f, 0, 


### PR DESCRIPTION
As title states. AdLib/Sound Blaster does not fit because AdLib preset already has its own drums mode preset, and the other Sound Blaster preset does not have AdLib shown.