### PR TITLE
Adjust System 32 preset flags to reflect chip used

### DIFF
--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -1408,7 +1408,7 @@ void FurnaceGUI::initSystemPresets() {
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // ^^
       CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
-        "clockSel=2\n", 
+        "clockSel=2\n" 
         "chipType=1\n"
       ) // 12.5MHz
     }
@@ -1418,7 +1418,7 @@ void FurnaceGUI::initSystemPresets() {
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // ^^
       CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
-        "clockSel=2\n", 
+        "clockSel=2\n" 
         "chipType=1\n"
       ) // 12.5MHz
     }
@@ -1428,7 +1428,7 @@ void FurnaceGUI::initSystemPresets() {
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // ^^
       CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
-        "clockSel=2\n", 
+        "clockSel=2\n" 
         "chipType=1\n"
       ) // 12.5MHz
     }
@@ -1438,7 +1438,7 @@ void FurnaceGUI::initSystemPresets() {
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // ^^
       CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
-        "clockSel=2\n", 
+        "clockSel=2\n" 
         "chipType=1\n"
       ) // 12.5MHz
     }

--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -1407,28 +1407,40 @@ void FurnaceGUI::initSystemPresets() {
     "Sega System 32", {
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // ^^
-      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, "clockSel=2") // 12.5MHz
+      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
+        "clockSel=2\n", 
+        "chipType=1\n"
+      ) // 12.5MHz
     }
   );
   ENTRY(
     "Sega System 32 (extended channel 3 on first OPN2C)", {
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // ^^
-      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, "clockSel=2") // 12.5MHz
+      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
+        "clockSel=2\n", 
+        "chipType=1\n"
+      ) // 12.5MHz
     }
   );
   ENTRY(
     "Sega System 32 (extended channel 3 on second OPN2C)", {
       CH(DIV_SYSTEM_YM2612, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // ^^
-      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, "clockSel=2") // 12.5MHz
+      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
+        "clockSel=2\n", 
+        "chipType=1\n"
+      ) // 12.5MHz
     }
   );
   ENTRY(
     "Sega System 32 (extended channel 3 on both OPN2Cs)", {
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // discrete 8.05MHz YM3438
       CH(DIV_SYSTEM_YM2612_EXT, 1.0f, 0, "clockSel=4"), // ^^
-      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, "clockSel=2") // 12.5MHz
+      CH(DIV_SYSTEM_RF5C68, 1.0f, 0, 
+        "clockSel=2\n", 
+        "chipType=1\n"
+      ) // 12.5MHz
     }
   );
   ENTRY(


### PR DESCRIPTION
Both the System 32 and the Mega CD use the 315-5476A, a rebadged RF5C164, instead of the System 18's ASSP 5C68A, which I believe is a RF5C68 as it says on the chip.