### PR TITLE
Radio button group indents everywhere.

### DIFF
--- a/src/gui/compatFlags.cpp
+++ b/src/gui/compatFlags.cpp
@@ -199,6 +199,7 @@ void FurnaceGUI::drawCompatFlags() {
       }
       if (ImGui::BeginTabItem("Pitch/Playback")) {
         ImGui::Text("Pitch linearity:");
+        ImGui::Indent();
         if (ImGui::RadioButton("None",e->song.linearPitch==0)) {
           e->song.linearPitch=0;
         }
@@ -217,6 +218,7 @@ void FurnaceGUI::drawCompatFlags() {
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip("like Impulse Tracker");
         }
+        ImGui::Unindent();
 
         if (e->song.linearPitch==2) {
           ImGui::SameLine();
@@ -228,6 +230,7 @@ void FurnaceGUI::drawCompatFlags() {
         }
 
         ImGui::Text("Loop modality:");
+        ImGui::Indent();
         if (ImGui::RadioButton("Reset channels",e->song.loopModality==0)) {
           e->song.loopModality=0;
         }
@@ -246,8 +249,10 @@ void FurnaceGUI::drawCompatFlags() {
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip("select to not reset channels on loop.");
         }
+        ImGui::Unindent();
 
         ImGui::Text("Cut/delay effect policy:");
+        ImGui::Indent();
         if (ImGui::RadioButton("Strict",e->song.delayBehavior==0)) {
           e->song.delayBehavior=0;
         }
@@ -266,8 +271,10 @@ void FurnaceGUI::drawCompatFlags() {
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip("no checks");
         }
+        ImGui::Unindent();
 
         ImGui::Text("Simultaneous jump (0B+0D) treatment:");
+        ImGui::Indent();
         if (ImGui::RadioButton("Normal",e->song.jumpTreatment==0)) {
           e->song.jumpTreatment=0;
         }
@@ -286,6 +293,7 @@ void FurnaceGUI::drawCompatFlags() {
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip("only accept 0Dxx");
         }
+        ImGui::Unindent();
         ImGui::EndTabItem();
       }
       if (ImGui::BeginTabItem("Other")) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -4013,6 +4013,7 @@ bool FurnaceGUI::loop() {
           ImGui::Checkbox("loop",&vgmExportLoop);
           if (vgmExportLoop && e->song.loopModality==2) {
             ImGui::Text("loop trail:");
+            ImGui::Indent();
             if (ImGui::RadioButton("auto-detect",vgmExportTrailingTicks==-1)) {
               vgmExportTrailingTicks=-1;
             }
@@ -4028,6 +4029,7 @@ bool FurnaceGUI::loop() {
                 if (vgmExportTrailingTicks<0) vgmExportTrailingTicks=0;
               }
             }
+            ImGui::Unindent();
           }
           ImGui::Checkbox("add pattern change hints",&vgmExportPatternHints);
           if (ImGui::IsItemHovered()) {

--- a/src/gui/piano.cpp
+++ b/src/gui/piano.cpp
@@ -100,6 +100,7 @@ void FurnaceGUI::drawPiano() {
         }
         if (ImGui::BeginPopupContextItem("PianoOptions",ImGuiPopupFlags_MouseButtonLeft)) {
           ImGui::Text("Key layout:");
+          ImGui::Indent();
           if (ImGui::RadioButton("Automatic",pianoView==PIANO_LAYOUT_AUTOMATIC)) {
             pianoView=PIANO_LAYOUT_AUTOMATIC;
           }
@@ -109,7 +110,9 @@ void FurnaceGUI::drawPiano() {
           if (ImGui::RadioButton("Continuous",pianoView==PIANO_LAYOUT_CONTINUOUS)) {
             pianoView=PIANO_LAYOUT_CONTINUOUS;
           }
+          ImGui::Unindent();
           ImGui::Text("Value input pad:");
+          ImGui::Indent();
           if (ImGui::RadioButton("Disabled",pianoInputPadMode==PIANO_INPUT_PAD_DISABLE)) {
             pianoInputPadMode=PIANO_INPUT_PAD_DISABLE;
           }
@@ -122,6 +125,7 @@ void FurnaceGUI::drawPiano() {
           if (ImGui::RadioButton("Split (always visible)",pianoInputPadMode==PIANO_INPUT_PAD_SPLIT_VISIBLE)) {
             pianoInputPadMode=PIANO_INPUT_PAD_SPLIT_VISIBLE;
           }
+          ImGui::Unindent();
           ImGui::Checkbox("Share play/edit offset/range",&pianoSharePosition);
           ImGui::Checkbox("Read-only (can't input notes)",&pianoReadonly);
           ImGui::EndPopup();


### PR DESCRIPTION
This should be all of them, everywhere it makes sense.

I've left the find/replace dialog alone. Those have a specific layout already.