### PR TITLE
Assets tab.

### DIFF
--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -436,11 +436,17 @@ void FurnaceGUI::drawInsList(bool asChild) {
     nextWindow=GUI_WINDOW_NOTHING;
   }
   if (!insListOpen && !asChild) return;
+  const char* label;
+  if (settings.unifiedDataView) { 
+      label="Assets";
+  } else {
+      label="Instruments";
+  }
   bool began=false;
   if (asChild) {
-    began=ImGui::BeginChild("Instruments");
+    began=ImGui::BeginChild(label);
   } else {
-    began=ImGui::Begin("Instruments",&insListOpen,globalWinFlags);
+    began=ImGui::Begin(label,&insListOpen,globalWinFlags);
   }
   if (began) {
     if (settings.unifiedDataView) settings.horizontalDataView=0;

--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -438,9 +438,9 @@ void FurnaceGUI::drawInsList(bool asChild) {
   if (!insListOpen && !asChild) return;
   const char* label;
   if (settings.unifiedDataView) { 
-      label="Assets";
+      label="Assets###Instruments";
   } else {
-      label="Instruments";
+      label="Instruments###Instruments";
   }
   bool began=false;
   if (asChild) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -771,7 +771,7 @@ Size=345,217\n\
 Collapsed=0\n\
 DockId=0x00000007,0\n\
 \n\
-[Window][Instruments]\n\
+[Window][###Instruments]\n\
 Pos=653,24\n\
 Size=323,217\n\
 Collapsed=0\n\
@@ -788,12 +788,6 @@ Pos=653,24\n\
 Size=323,217\n\
 Collapsed=0\n\
 DockId=0x00000006,2\n\
-\n\
-[Window][Assets]\n\
-Pos=653,24\n\
-Size=323,217\n\
-Collapsed=0\n\
-DockId=0x00000006,0\n\
 \n\
 [Window][Pattern]\n\
 Pos=0,243\n\

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -789,6 +789,12 @@ Size=323,217\n\
 Collapsed=0\n\
 DockId=0x00000006,2\n\
 \n\
+[Window][Assets]\n\
+Pos=653,24\n\
+Size=323,217\n\
+Collapsed=0\n\
+DockId=0x00000006,0\n\
+\n\
 [Window][Pattern]\n\
 Pos=0,243\n\
 Size=939,557\n\


### PR DESCRIPTION
Before: The "unified inst/wave/samp" setting reused the instruments tab, meaning the window was still labelled "Instruments" and there were still menu items for the no-longer-accessible wave and sample windows.

After: "Assets" counts as its own window! Above issues solved.