### PR TITLE
ZSM: add optimize for size toggle

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -605,7 +605,7 @@ class DivEngine {
     // - -2 to add a whole loop of trailing
     SafeWriter* saveVGM(bool* sysToExport=NULL, bool loop=true, int version=0x171, bool patternHints=false, bool directStream=false, int trailingTicks=-1);
     // dump to ZSM.
-    SafeWriter* saveZSM(unsigned int zsmrate=60, bool loop=true);
+    SafeWriter* saveZSM(unsigned int zsmrate=60, bool loop=true, bool optimize=true);
     // dump command stream.
     SafeWriter* saveCommand(bool binary=false);
     // export to an audio file

--- a/src/engine/zsm.cpp
+++ b/src/engine/zsm.cpp
@@ -67,7 +67,7 @@ void DivZSM::init(unsigned int rate) {
   ymMask=0;
   psgMask=0;
   // Optimize writes
-  optimize=false;
+  optimize=true;
 }
 
 int DivZSM::getoffset() {
@@ -213,7 +213,7 @@ void DivZSM::setLoopPoint() {
 }
 
 void DivZSM::setOptimize(bool o) {
-  optimize = o;
+  optimize=o;
 }
 
 SafeWriter* DivZSM::finish() {
@@ -284,8 +284,8 @@ void DivZSM::flushWrites() {
     // if optimize=true, suppress writes to PSG voices that are not audible (volume=0 or R+L=0)
     // ZSMKit has a feature that can benefit from having silent channels
     // updated, so this is something that can be toggled off or on for export
-    if (optimize && i%4!=2 && (psgState[psg_NEW][(i&0x3c)+2]&0x3f)==0) continue; // vol
-    if (optimize && i%4!=2 && (psgState[psg_NEW][(i&0x3c)+2]&0xc0)==0) continue; // R+L
+    if (optimize && (i&3)!=2 && (psgState[psg_NEW][(i&0x3c)+2]&0x3f)==0) continue; // vol
+    if (optimize && (i&3)!=2 && (psgState[psg_NEW][(i&0x3c)+2]&0xc0)==0) continue; // R+L
     psgState[psg_PREV][i]=psgState[psg_NEW][i];
     w->writeC(i);
     w->writeC(psgState[psg_NEW][i]);

--- a/src/engine/zsm.h
+++ b/src/engine/zsm.h
@@ -70,6 +70,7 @@ class DivZSM {
     int tickRate;
     int ymMask;
     int psgMask;
+    bool optimize;
   public:
     DivZSM();
     ~DivZSM();
@@ -79,6 +80,7 @@ class DivZSM {
     void writePSG(unsigned char a, unsigned char v);
     void writePCM(unsigned char a, unsigned char v);
     void writeSync(unsigned char a, unsigned char v);
+    void setOptimize(bool o);
     void tick(int numticks = 1);
     void setLoopPoint();
     SafeWriter* finish();

--- a/src/engine/zsmOps.cpp
+++ b/src/engine/zsmOps.cpp
@@ -26,7 +26,7 @@
 constexpr int MASTER_CLOCK_PREC=(sizeof(void*)==8)?8:0;
 constexpr int MASTER_CLOCK_MASK=(sizeof(void*)==8)?0xff:0;
 
-SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop) {
+SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop, bool optimize) {
   int VERA=-1;
   int YM=-1;
   int IGNORED=0;
@@ -118,6 +118,9 @@ SafeWriter* DivEngine::saveZSM(unsigned int zsmrate, bool loop) {
   // by nature of overflowing the signed char value
   signed char tuningoffset=(signed char)(round(3072*(log(song.tuning/440.0)/log(2))))&0xff;
   zsm.writeSync(0x01,tuningoffset);
+  // Set optimize flag, which mainly buffers PSG writes
+  // whenever the channel is silent
+  zsm.setOptimize(optimize);
 
   while (!done) {
     if (loopPos==-1) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -4108,6 +4108,8 @@ bool FurnaceGUI::loop() {
             }
             ImGui::Checkbox("loop",&zsmExportLoop);
             ImGui::SameLine();
+            ImGui::Checkbox("optimize size",&zsmExportOptimize);
+            ImGui::SameLine();
             if (ImGui::Button("Begin Export")) {
               openFileDialog(GUI_FILE_EXPORT_ZSM);
               ImGui::CloseCurrentPopup();
@@ -5067,7 +5069,7 @@ bool FurnaceGUI::loop() {
               break;
             }
             case GUI_FILE_EXPORT_ZSM: {
-              SafeWriter* w=e->saveZSM(zsmExportTickRate,zsmExportLoop);
+              SafeWriter* w=e->saveZSM(zsmExportTickRate,zsmExportLoop,zsmExportOptimize);
               if (w!=NULL) {
                 FILE* f=ps_fopen(copyOfName.c_str(),"wb");
                 if (f!=NULL) {
@@ -6799,6 +6801,7 @@ FurnaceGUI::FurnaceGUI():
   displayExporting(false),
   vgmExportLoop(true),
   zsmExportLoop(true),
+  zsmExportOptimize(true),
   vgmExportPatternHints(false),
   vgmExportDirectStream(false),
   displayInsTypeList(false),

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1324,7 +1324,7 @@ class FurnaceGUI {
   std::vector<String> availRenderDrivers;
   std::vector<String> availAudioDrivers;
 
-  bool quit, warnQuit, willCommit, edit, modified, displayError, displayExporting, vgmExportLoop, zsmExportLoop, vgmExportPatternHints;
+  bool quit, warnQuit, willCommit, edit, modified, displayError, displayExporting, vgmExportLoop, zsmExportLoop, zsmExportOptimize, vgmExportPatternHints;
   bool vgmExportDirectStream, displayInsTypeList;
   bool portrait, injectBackUp, mobileMenuOpen, warnColorPushed;
   bool wantCaptureKeyboard, oldWantCaptureKeyboard, displayMacroMenu;


### PR DESCRIPTION
Before this change, VERA PSG writes would be output even if they did not affect the sound output of the chip due to a channel being silent. This commit adds a toggle for "optimize size" on the ZSM export dialog, enabled by default. When this is enabled, no register updates are output if the voice is effectively muted, which can substantially reduce export size if a pitch slide, vibrato, or PWM effect is running after the sound has decayed to 0.  On the tick which sets the volume to something other than 0, the buffered writes are then output.

I chose to leave an option available for the old behavior for two reasons
- ZSMKit has a planned feature which takes advantage of being able to read the pitch in a silent channel and controlling the volume envelope separately. A special case for certain game logic.
- Setting the R+L off on VERA is how its channel phase is reset. I can imagine there being some edge case where a composer asked for a phase reset on a channel and wants to set up the pitch ahead of making the channel audible. While this scenario seems unlikely, I don't want this feature to stand in the way in case that's ever used.

tl;dr, this feature should help reduce ZSM export size, potentially substantially, and should be used in almost all cases.