### PR TITLE
Move chanOsc "Center waveform" option to next line.

### DIFF
--- a/src/gui/chanOsc.cpp
+++ b/src/gui/chanOsc.cpp
@@ -128,7 +128,7 @@ void FurnaceGUI::drawChanOsc() {
     bool centerSettingReset=false;
     ImDrawList* dl=ImGui::GetWindowDrawList();
     if (chanOscOptions) {
-      if (ImGui::BeginTable("ChanOscSettings",3)) {
+      if (ImGui::BeginTable("ChanOscSettings",2)) {
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();
@@ -150,11 +150,6 @@ void FurnaceGUI::drawChanOsc() {
         }
 
         ImGui::TableNextColumn();
-        if (ImGui::Checkbox("Center waveform",&chanOscWaveCorr)) {
-          centerSettingReset=true;
-        }
-
-        ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();
         ImGui::Text("Automatic columns");
         ImGui::SameLine();
@@ -167,6 +162,11 @@ void FurnaceGUI::drawChanOsc() {
             if (isSelected) ImGui::SetItemDefaultFocus();
           }
           ImGui::EndCombo();
+        }
+
+        ImGui::TableNextColumn();
+        if (ImGui::Checkbox("Center waveform",&chanOscWaveCorr)) {
+          centerSettingReset=true;
         }
         ImGui::EndTable();
       }

--- a/src/gui/chanOsc.cpp
+++ b/src/gui/chanOsc.cpp
@@ -149,6 +149,7 @@ void FurnaceGUI::drawChanOsc() {
           if (chanOscWindowSize>50.0f) chanOscWindowSize=50.0f;
         }
 
+        ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();
         ImGui::Text("Automatic columns");


### PR DESCRIPTION
Tiny little adjustment that I originally thought would come with resizing color selectors; gave up on those but this is still useful? Anyhow, it alleviates a bit of the "narrow window can't reach controls" effect and, I think, groups the options better.