### PR TITLE
appdata: Add url

### DIFF
--- a/res/furnace.appdata.xml
+++ b/res/furnace.appdata.xml
@@ -4,6 +4,7 @@
   
   <name>Furnace</name>
   <summary>Open-source chiptune tracker</summary>
+  <url type="homepage">https://github.com/tildearrow/furnace</url>
   
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>


### PR DESCRIPTION
I'm putting together a flatpak build: https://github.com/flathub/flathub/pull/4504.
@tildearrow, would you be okay with Furnace being distributed via flathub?

The flathub buildbot requires the AppStream to have a `url` and `releases` field.
This MR only solves the `url` issue.
Currently the flathub buildbot is failing with:
```
$ flatpak run --command=appstream-util org.flatpak.Builder validate res/furnace.appdata.xml
res/furnace.appdata.xml: FAILED:
• tag-missing           : <release> required
• tag-missing           : <url> is not present
Validation of files failed
```

The AppStream docs suggest using a tilde in the version number of pre-release releases (`0.6~pre14`) as it considers `0.6` to be a lower version to `0.6pre14`: [AppStream/VerCmp](https://www.freedesktop.org/software/appstream/docs/chap-AppStream-Misc.html#sect-AppStream-Misc-VerCmp).

The `releases` field could be automated should look something like:
```
  <releases>
    <release version="0.6~pre14" date="2023-09-11" type="development">
      <url>https://github.com/tildearrow/furnace/releases/tag/v0.6pre14</url>
    </release>
  </releases>
```

Also, currently the app id is `org.tildearrow.furnace` with a lowercase F which I assume is intentional.

Out of interest my distros version of `appstream-util` has extra complaints about the big screenshot :
```
• attribute-invalid     : <screenshot> width too large [https://tildearrow.org/storage/images/furnace.png] maximum is 1600px
• attribute-invalid     : <screenshot> height too large [https://tildearrow.org/storage/images/furnace.png] maximum is 900px
```