### PR TITLE
appdata: Remove b tag from description

### DIFF
--- a/res/furnace.appdata.xml
+++ b/res/furnace.appdata.xml
@@ -20,7 +20,7 @@
       it also offers DefleMask compatibility, allowing you to import your songs and even export them back for interoperability.
     </p>
     <p>
-      <b>rationale for intense profanity:</b> the tracker itself is clean, but a few demo songs and instruments contain a small amount of strong language.
+      rationale for intense profanity: the tracker itself is clean, but a few demo songs and instruments contain a small amount of strong language.
     </p>
   </description>
 

--- a/res/furnace.appdata.xml.in
+++ b/res/furnace.appdata.xml.in
@@ -20,7 +20,7 @@
       it also offers DefleMask compatibility, allowing you to import your songs and even export them back for interoperability.
     </p>
     <p>
-      <b>rationale for intense profanity:</b> the tracker itself is clean, but a few demo songs and instruments contain a small amount of strong language.
+      rationale for intense profanity: the tracker itself is clean, but a few demo songs and instruments contain a small amount of strong language.
     </p>
   </description>
 


### PR DESCRIPTION
AppStream doesn't have a way of making things bold, the closest is `em` for italics: [AppStream#tag-description](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description)

Gnome Software Before:
![Screenshot from 2023-09-12 15-55-33](https://github.com/tildearrow/furnace/assets/334272/af3c9771-9c5e-45f0-89ab-f32e388479e7)

Gnome Software After:
![Screenshot from 2023-09-12 16-03-02](https://github.com/tildearrow/furnace/assets/334272/3188dae9-d062-4220-a8c9-f932d53ecad1)
