### PR TITLE
add C64 ADSR and separate cutoff macros, add gate bit to test/gate macro, untested fix of macro retrigger on 03xx command

### DIFF
--- a/src/engine/fileOps.cpp
+++ b/src/engine/fileOps.cpp
@@ -3008,11 +3008,12 @@ bool DivEngine::loadFur(unsigned char* file, size_t len) {
       }
     }
 
-    // C64 1Exy compat
+    // C64 1Exy and old version test bit macro compat
     if (ds.version<186) {
       for (int i=0; i<ds.systemLen; i++) {
         if (ds.system[i]==DIV_SYSTEM_C64_8580 || ds.system[i]==DIV_SYSTEM_C64_6581) {
           ds.systemFlags[i].set("no1EUpdate",true);
+		  ds.systemFlags[i].set("newTestBitMacro",true);
         }
       }
     }

--- a/src/engine/platform/c64.cpp
+++ b/src/engine/platform/c64.cpp
@@ -220,7 +220,30 @@ void DivPlatformC64::tick(bool sysTick) {
     }
     if (chan[i].std.ex4.had) {
       chan[i].test=chan[i].std.ex4.val&1;
+
+      if (newTestBitMacro)
+      {
+          chan[i].active = chan[i].std.ex4.val & 2;
+          if (!chan[i].active)
+          {
+              chan[i].keyOff = true;
+              chan[i].keyOn = false;
+          }
+      }
+      
       rWrite(i*7+4,(chan[i].wave<<4)|(chan[i].test<<3)|(chan[i].ring<<2)|(chan[i].sync<<1)|(int)(chan[i].active));
+    }
+
+    if (chan[i].std.ex5.had) {
+        chan[i].attack = chan[i].std.ex5.val >> 4;
+        chan[i].decay = chan[i].std.ex5.val & 15;
+        rWrite(i * 7 + 5, (chan[i].attack << 4) | (chan[i].decay));
+    }
+
+    if (chan[i].std.ex6.had) {
+        chan[i].sustain = chan[i].std.ex6.val >> 4;
+        chan[i].release = chan[i].std.ex6.val & 15;
+        rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
     }
 
     if (sysTick) {
@@ -396,7 +419,7 @@ int DivPlatformC64::dispatch(DivCommand c) {
       break;
     case DIV_CMD_PRE_PORTA:
       if (chan[c.chan].active && c.value2) {
-        if (parent->song.resetMacroOnPorta || !chan[c.chan].inPorta) {
+        if (parent->song.resetMacroOnPorta) {// || !chan[c.chan].inPorta) {
           chan[c.chan].macroInit(parent->getIns(chan[c.chan].ins,DIV_INS_C64));
           chan[c.chan].keyOn=true;
         }
@@ -675,6 +698,7 @@ void DivPlatformC64::setFlags(const DivConfig& flags) {
   }
   keyPriority=flags.getBool("keyPriority",true);
   no1EUpdate=flags.getBool("no1EUpdate",false);
+  newTestBitMacro = flags.getBool("oldTestBitMacro", false);
   testAD=((flags.getInt("testAttack",0)&15)<<4)|(flags.getInt("testDecay",0)&15);
   testSR=((flags.getInt("testSustain",0)&15)<<4)|(flags.getInt("testRelease",0)&15);
 

--- a/src/engine/platform/c64.cpp
+++ b/src/engine/platform/c64.cpp
@@ -173,6 +173,19 @@ void DivPlatformC64::tick(bool sysTick) {
         willUpdateFilter=true;
       }
     }
+    if (chan[i].std.alg.had) { //new cutoff macro!
+        DivInstrument* ins = parent->getIns(chan[i].ins, DIV_INS_C64);
+        if (ins->c64.filterIsAbs) {
+            filtCut = MIN(2047, chan[i].std.alg.val);
+        }
+        else {
+            filtCut += ((signed char)chan[i].std.alg.val) * 7; //new macro should not be executed in inverted way when in relative mode jesus
+            if (filtCut > 2047) filtCut = 2047;
+            if (filtCut < 0) filtCut = 0;
+        }
+        willUpdateFilter = true;
+    }
+
     if (NEW_ARP_STRAT) {
       chan[i].handleArp();
     } else if (chan[i].std.arp.had) {

--- a/src/engine/platform/c64.cpp
+++ b/src/engine/platform/c64.cpp
@@ -235,13 +235,21 @@ void DivPlatformC64::tick(bool sysTick) {
     }
 
     if (chan[i].std.ex5.had) {
-        chan[i].attack = chan[i].std.ex5.val >> 4;
-        chan[i].decay = chan[i].std.ex5.val & 15;
+        chan[i].attack = chan[i].std.ex5.val & 15;
         rWrite(i * 7 + 5, (chan[i].attack << 4) | (chan[i].decay));
     }
 
     if (chan[i].std.ex6.had) {
-        chan[i].sustain = chan[i].std.ex6.val >> 4;
+        chan[i].decay = chan[i].std.ex5.val & 15;
+        rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
+    }
+
+    if (chan[i].std.ex7.had) {
+        chan[i].sustain = chan[i].std.ex6.val & 15;
+        rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
+    }
+
+    if (chan[i].std.ex8.had) {
         chan[i].release = chan[i].std.ex6.val & 15;
         rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
     }

--- a/src/engine/platform/c64.cpp
+++ b/src/engine/platform/c64.cpp
@@ -706,7 +706,7 @@ void DivPlatformC64::setFlags(const DivConfig& flags) {
   }
   keyPriority=flags.getBool("keyPriority",true);
   no1EUpdate=flags.getBool("no1EUpdate",false);
-  newTestBitMacro = flags.getBool("oldTestBitMacro", false);
+  newTestBitMacro = flags.getBool("newTestBitMacro", false);
   testAD=((flags.getInt("testAttack",0)&15)<<4)|(flags.getInt("testDecay",0)&15);
   testSR=((flags.getInt("testSustain",0)&15)<<4)|(flags.getInt("testRelease",0)&15);
 

--- a/src/engine/platform/c64.cpp
+++ b/src/engine/platform/c64.cpp
@@ -240,17 +240,17 @@ void DivPlatformC64::tick(bool sysTick) {
     }
 
     if (chan[i].std.ex6.had) {
-        chan[i].decay = chan[i].std.ex5.val & 15;
-        rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
+        chan[i].decay = chan[i].std.ex6.val & 15;
+        rWrite(i * 7 + 5, (chan[i].attack << 4) | (chan[i].decay));
     }
 
     if (chan[i].std.ex7.had) {
-        chan[i].sustain = chan[i].std.ex6.val & 15;
+        chan[i].sustain = chan[i].std.ex7.val & 15;
         rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
     }
 
     if (chan[i].std.ex8.had) {
-        chan[i].release = chan[i].std.ex6.val & 15;
+        chan[i].release = chan[i].std.ex8.val & 15;
         rWrite(i * 7 + 6, (chan[i].sustain << 4) | (chan[i].release));
     }
 

--- a/src/engine/platform/c64.h
+++ b/src/engine/platform/c64.h
@@ -72,7 +72,7 @@ class DivPlatformC64: public DivDispatch {
   unsigned char sidCore;
   int filtCut, resetTime;
 
-  bool keyPriority, sidIs6581, needInitTables, no1EUpdate;
+  bool keyPriority, sidIs6581, needInitTables, no1EUpdate, newTestBitMacro;
   unsigned char chanOrder[3];
   unsigned char testAD, testSR;
 

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -256,6 +256,18 @@ const char* c64SpecialBits[3]={
   "sync", "ring", NULL
 };
 
+const char* c64TestGateBits[3]={
+  "test", "gate", NULL
+};
+
+const char* c64AttackDecayBits[9] = {
+  "Decay 1", "Decay 2", "Decay 3", "Decay 4", "Attack 1", "Attack 2", "Attack 3", "Attack 4", NULL
+};
+
+const char* c64SustainReleaseBits[9] = {
+  "Release 1", "Release 2", "Release 3", "Release 4", "Sustain 1", "Sustain 2", "Sustain 3", "Sustain 4", NULL
+};
+
 const char* pokeyCtlBits[9]={
   "15KHz", "filter 2+4", "filter 1+3", "16-bit 3+4", "16-bit 1+2", "high3", "high1", "poly9", NULL
 };
@@ -6479,7 +6491,10 @@ void FurnaceGUI::drawInsEdit() {
           }
           if (ins->type==DIV_INS_C64) {
             macroList.push_back(FurnaceGUIMacroDesc("Special",&ins->std.ex3Macro,0,2,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true,c64SpecialBits));
-            macroList.push_back(FurnaceGUIMacroDesc("Test/Gate",&ins->std.ex4Macro,0,1,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true));
+            //macroList.push_back(FurnaceGUIMacroDesc("Test/Gate",&ins->std.ex4Macro,0,1,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true));
+			macroList.push_back(FurnaceGUIMacroDesc("Test/Gate",&ins->std.ex4Macro,0,2,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL, true, c64TestGateBits));
+            macroList.push_back(FurnaceGUIMacroDesc("Attack/Decay", &ins->std.ex5Macro, 0, 8, 128, uiColors[GUI_COLOR_MACRO_OTHER], false, NULL, NULL, true, c64AttackDecayBits));
+            macroList.push_back(FurnaceGUIMacroDesc("Sustain/Release", &ins->std.ex6Macro, 0, 8, 128, uiColors[GUI_COLOR_MACRO_OTHER], false, NULL, NULL, true, c64SustainReleaseBits));
           }
           if (ins->type==DIV_INS_AY || ins->type==DIV_INS_AY8930 || (ins->type==DIV_INS_X1_010 && !ins->amiga.useSample)) {
             macroList.push_back(FurnaceGUIMacroDesc("AutoEnv Num",&ins->std.ex3Macro,0,15,160,uiColors[GUI_COLOR_MACRO_OTHER]));

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -260,14 +260,6 @@ const char* c64TestGateBits[3]={
   "test", "gate", NULL
 };
 
-const char* c64AttackDecayBits[9] = {
-  "Decay 1", "Decay 2", "Decay 3", "Decay 4", "Attack 1", "Attack 2", "Attack 3", "Attack 4", NULL
-};
-
-const char* c64SustainReleaseBits[9] = {
-  "Release 1", "Release 2", "Release 3", "Release 4", "Sustain 1", "Sustain 2", "Sustain 3", "Sustain 4", NULL
-};
-
 const char* pokeyCtlBits[9]={
   "15KHz", "filter 2+4", "filter 1+3", "16-bit 3+4", "16-bit 1+2", "high3", "high1", "poly9", NULL
 };
@@ -6493,8 +6485,10 @@ void FurnaceGUI::drawInsEdit() {
             macroList.push_back(FurnaceGUIMacroDesc("Special",&ins->std.ex3Macro,0,2,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true,c64SpecialBits));
             //macroList.push_back(FurnaceGUIMacroDesc("Test/Gate",&ins->std.ex4Macro,0,1,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true));
 			macroList.push_back(FurnaceGUIMacroDesc("Test/Gate",&ins->std.ex4Macro,0,2,32,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL, true, c64TestGateBits));
-            macroList.push_back(FurnaceGUIMacroDesc("Attack/Decay", &ins->std.ex5Macro, 0, 8, 128, uiColors[GUI_COLOR_MACRO_OTHER], false, NULL, NULL, true, c64AttackDecayBits));
-            macroList.push_back(FurnaceGUIMacroDesc("Sustain/Release", &ins->std.ex6Macro, 0, 8, 128, uiColors[GUI_COLOR_MACRO_OTHER], false, NULL, NULL, true, c64SustainReleaseBits));
+            macroList.push_back(FurnaceGUIMacroDesc("Attack", &ins->std.ex5Macro, 0, 15, 128, uiColors[GUI_COLOR_MACRO_OTHER]));
+            macroList.push_back(FurnaceGUIMacroDesc("Decay", &ins->std.ex6Macro, 0, 15, 128, uiColors[GUI_COLOR_MACRO_OTHER]));
+            macroList.push_back(FurnaceGUIMacroDesc("Sustain", &ins->std.ex7Macro, 0, 15, 128, uiColors[GUI_COLOR_MACRO_OTHER]));
+            macroList.push_back(FurnaceGUIMacroDesc("Release", &ins->std.ex8Macro, 0, 15, 128, uiColors[GUI_COLOR_MACRO_OTHER]));
           }
           if (ins->type==DIV_INS_AY || ins->type==DIV_INS_AY8930 || (ins->type==DIV_INS_X1_010 && !ins->amiga.useSample)) {
             macroList.push_back(FurnaceGUIMacroDesc("AutoEnv Num",&ins->std.ex3Macro,0,15,160,uiColors[GUI_COLOR_MACRO_OTHER]));

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -6437,6 +6437,15 @@ void FurnaceGUI::drawInsEdit() {
           }
           if (ex1Max>0) {
             if (ins->type==DIV_INS_C64) {
+                int cutoffmin = -64;
+                int cutoffmax = 64;
+
+                if (ins->c64.filterIsAbs) {
+                    ins->std.algMacro.vZoom = -1;
+                    cutoffmin = 0;
+                    cutoffmax = 2047;
+                }
+              macroList.push_back(FurnaceGUIMacroDesc("Filter Cutoff", &ins->std.algMacro, cutoffmin, cutoffmax, 160, uiColors[GUI_COLOR_MACRO_OTHER]));
               macroList.push_back(FurnaceGUIMacroDesc("Filter Mode",&ins->std.ex1Macro,0,ex1Max,64,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true,filtModeBits));
             } else if (ins->type==DIV_INS_SAA1099) {
               macroList.push_back(FurnaceGUIMacroDesc("Envelope",&ins->std.ex1Macro,0,ex1Max,160,uiColors[GUI_COLOR_MACRO_OTHER],false,NULL,NULL,true,saaEnvBits));

--- a/src/gui/sysConf.cpp
+++ b/src/gui/sysConf.cpp
@@ -587,6 +587,7 @@ bool FurnaceGUI::drawSysConf(int chan, int sysPos, DivSystem type, DivConfig& fl
       int clockSel=flags.getInt("clockSel",0);
       bool keyPriority=flags.getBool("keyPriority",true);
       bool no1EUpdate=flags.getBool("no1EUpdate",false);
+      bool newTestBitMacro = flags.getBool("newTestBitMacro", false);
       int testAttack=flags.getInt("testAttack",0);
       int testDecay=flags.getInt("testDecay",0);
       int testSustain=flags.getInt("testSustain",0);
@@ -649,11 +650,16 @@ bool FurnaceGUI::drawSysConf(int chan, int sysPos, DivSystem type, DivConfig& fl
         altered=true;
       }
 
+      if (ImGui::Checkbox("New test bit macro behaviour (with gate bit) (compatibility)", &newTestBitMacro)) {
+          altered = true;
+      }
+
       if (altered) {
         e->lockSave([&]() {
           flags.set("clockSel",clockSel);
           flags.set("keyPriority",keyPriority);
           flags.set("no1EUpdate",no1EUpdate);
+          flags.set("newTestBitMacro", newTestBitMacro);
           flags.set("testAttack",testAttack);
           flags.set("testDecay",testDecay);
           flags.set("testSustain",testSustain);


### PR DESCRIPTION
Lmao finally 4 macros for ADSR params (remember sustain goes only down or you just cut the sound lol)
Also a filter cutoff macro -- no need to choose between volume and cutoff anymore!
Also jank compat flag idk
I tested it on my unfinished C64 module and on test instruments and ADSR params and gate bit work as expected idk
