### PR TITLE
Add a new compatibility flag: Round linear volumes up when scaling

### DIFF
--- a/papers/format.md
+++ b/papers/format.md
@@ -363,7 +363,7 @@ size | description
   1  | pre note (C64) does not compensate for portamento or legato (>=168)
   1  | disable new NES DPCM features (>=183)
   1  | reset arp effect phase on new note (>=184)
-  1  | linear volume scaling rounds up (>=187)
+  1  | linear volume scaling rounds up (>=188)
   2  | reserved
  --- | **speed pattern of first song** (>=139)
   1  | length of speed pattern (fail if this is lower than 0 or higher than 16)

--- a/papers/format.md
+++ b/papers/format.md
@@ -363,7 +363,8 @@ size | description
   1  | pre note (C64) does not compensate for portamento or legato (>=168)
   1  | disable new NES DPCM features (>=183)
   1  | reset arp effect phase on new note (>=184)
-  3  | reserved
+  1  | linear volume scaling rounds up (>=187)
+  2  | reserved
  --- | **speed pattern of first song** (>=139)
   1  | length of speed pattern (fail if this is lower than 0 or higher than 16)
  16  | speed pattern (this overrides speed 1 and speed 2 settings)

--- a/src/engine/dispatch.h
+++ b/src/engine/dispatch.h
@@ -782,7 +782,7 @@ class DivDispatch {
 #define NOTE_FNUM_BLOCK(x,bits) parent->calcBaseFreqFNumBlock(chipClock,CHIP_FREQBASE,x,bits)
 
 // this is for volume scaling calculation.
-#define VOL_SCALE_LINEAR(x,y,range) (((x)*(y))/(range))
+#define VOL_SCALE_LINEAR(x,y,range) ((parent->song.ceilVolumeScaling)?((((x)*(y))+(range-1))/(range)):(((x)*(y))/(range)))
 #define VOL_SCALE_LOG(x,y,range) (CLAMP(((x)+(y))-(range),0,(range)))
 #define VOL_SCALE_LINEAR_BROKEN(x,y,range) ((parent->song.newVolumeScaling)?(VOL_SCALE_LINEAR(x,y,range)):(VOL_SCALE_LOG(x,y,range)))
 #define VOL_SCALE_LOG_BROKEN(x,y,range) ((parent->song.newVolumeScaling)?(VOL_SCALE_LOG(x,y,range)):(VOL_SCALE_LINEAR(x,y,range)))

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -55,7 +55,7 @@ class DivWorkPool;
 #define DIV_UNSTABLE
 
 #define DIV_VERSION "dev187"
-#define DIV_ENGINE_VERSION 187
+#define DIV_ENGINE_VERSION 188
 // for imports
 #define DIV_VERSION_MOD 0xff01
 #define DIV_VERSION_FC 0xff02

--- a/src/engine/fileOps.cpp
+++ b/src/engine/fileOps.cpp
@@ -1873,7 +1873,7 @@ bool DivEngine::loadFur(unsigned char* file, size_t len) {
     if (ds.version<184) {
       ds.resetArpPhaseOnNewNote=false;
     }
-    if (ds.version<187) {
+    if (ds.version<188) {
       ds.ceilVolumeScaling=false;
     }
     ds.isDMF=false;
@@ -2412,7 +2412,7 @@ bool DivEngine::loadFur(unsigned char* file, size_t len) {
       } else {
         reader.readC();
       }
-      if (ds.version>=187) {
+      if (ds.version>=188) {
         ds.ceilVolumeScaling=reader.readC();
       } else {
         reader.readC();

--- a/src/engine/fileOps.cpp
+++ b/src/engine/fileOps.cpp
@@ -1873,6 +1873,9 @@ bool DivEngine::loadFur(unsigned char* file, size_t len) {
     if (ds.version<184) {
       ds.resetArpPhaseOnNewNote=false;
     }
+    if (ds.version<187) {
+      ds.ceilVolumeScaling=false;
+    }
     ds.isDMF=false;
 
     reader.readS(); // reserved
@@ -2409,7 +2412,12 @@ bool DivEngine::loadFur(unsigned char* file, size_t len) {
       } else {
         reader.readC();
       }
-      for (int i=0; i<3; i++) {
+      if (ds.version>=187) {
+        ds.ceilVolumeScaling=reader.readC();
+      } else {
+        reader.readC();
+      }
+      for (int i=0; i<2; i++) {
         reader.readC();
       }
     }
@@ -5494,7 +5502,8 @@ SafeWriter* DivEngine::saveFur(bool notPrimary, bool newPatternFormat) {
   w->writeC(song.preNoteNoEffect);
   w->writeC(song.oldDPCM);
   w->writeC(song.resetArpPhaseOnNewNote);
-  for (int i=0; i<3; i++) {
+  w->writeC(song.ceilVolumeScaling);
+  for (int i=0; i<2; i++) {
     w->writeC(0);
   }
 

--- a/src/engine/song.h
+++ b/src/engine/song.h
@@ -502,7 +502,7 @@ struct DivSong {
     preNoteNoEffect(false),
     oldDPCM(false),
     resetArpPhaseOnNewNote(false),
-    ceilVolumeScaling(false) { // DEBUG: before accepting PR, set this to false! (zeta hasn't touched the UI yet)
+    ceilVolumeScaling(false) {
     for (int i=0; i<DIV_MAX_CHIPS; i++) {
       system[i]=DIV_SYSTEM_NULL;
       systemVol[i]=1.0;

--- a/src/engine/song.h
+++ b/src/engine/song.h
@@ -379,6 +379,7 @@ struct DivSong {
   bool preNoteNoEffect;
   bool oldDPCM;
   bool resetArpPhaseOnNewNote;
+  bool ceilVolumeScaling;
 
   std::vector<DivInstrument*> ins;
   std::vector<DivWavetable*> wave;
@@ -500,7 +501,8 @@ struct DivSong {
     brokenFMOff(false),
     preNoteNoEffect(false),
     oldDPCM(false),
-    resetArpPhaseOnNewNote(false) {
+    resetArpPhaseOnNewNote(false),
+    ceilVolumeScaling(false) { // DEBUG: before accepting PR, set this to false! (zeta hasn't touched the UI yet)
     for (int i=0; i<DIV_MAX_CHIPS; i++) {
       system[i]=DIV_SYSTEM_NULL;
       systemVol[i]=1.0;

--- a/src/gui/compatFlags.cpp
+++ b/src/gui/compatFlags.cpp
@@ -336,6 +336,10 @@ void FurnaceGUI::drawCompatFlags() {
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip("when enabled, arpeggio effect (00xy) position is reset on a new note.");
         }
+        ImGui::Checkbox("Volume scaling rounds up",&e->song.ceilVolumeScaling);
+        if (ImGui::IsItemHovered()) {
+          ImGui::SetTooltip("when enabled, volume macros round up when applied\nthis prevents volume scaling from causing vol=0, which is silent on some chips\n\nineffective on logarithmic channels");
+        }
         ImGui::EndTabItem();
       }
       ImGui::EndTabBar();


### PR DESCRIPTION
Problem: Many chips treat vol=0 as completely silent. When mixing a volume macro in an instrument with a channel volume, a compositional intent to merely _quiet_ a sound can result in it going completely silent instead, if the result of volume scaling is allowed to become 0. Integer division floors the result, which causes this behavior.

Solution: With the new option ticked, all **linear** volume scaling now rounds up. This has subtle effects on the mix outside of merely avoiding the channel going silent, so it's presented as an flag rather than as a new default. It should please FamiTracker users, and those coming from other trackers which may expect this behavior.

![volume_scaling_gui](https://github.com/tildearrow/furnace/assets/1165075/2dfd4b18-ede4-4894-96f7-d755e5ff922a)

For persistence, I noticed a set of 3 reserved bytes in the song block, so I allocated the new flag to one of them rather than extending the block's length.

The attached module demonstrates the new behavior: even at very quiet volumes, the release (volmacro=1) is never forced to 0, and rings out as intended until manually silenced with an `OFF`.

[ceil_vol_test.fur.zip](https://github.com/tildearrow/furnace/files/13346776/ceil_vol_test.fur.zip)