### PR TITLE
Fix "App is damaged" error on newer macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1077,6 +1077,7 @@ if (NOT ANDROID OR TERMUX)
     set(CPACK_BUNDLE_PLIST ${CMAKE_SOURCE_DIR}/res/Info.plist)
     set(CPACK_BUNDLE_ICON ${CMAKE_SOURCE_DIR}/res/icon.icns)
     set(CPACK_BUNDLE_STARTUP_COMMAND "furnace")
+    set(CPACK_BUNDLE_APPLE_CERT_APP "-")
   endif()
   
   include(CPack)

--- a/res/Info.plist
+++ b/res/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>furnace</string>
+	<string>Furnace</string>
 	<key>CFBundleGetInfoString</key>
 	<string></string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
<!-- NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated! -->

These two simple changes should fix macOS complaining that the app is "damaged" when users download the DMG.

 * Corrected the executable name in the Info.plist. The Info.plist had the executable name set to "furnace", but in the app bundle it's actually named "Furnace" with a capital F, as CPack seems to rename the executable to match the bundle name. `codesign` will complain about this and call the Info.plist invalid.
 * Configured CPack to sign the bundle with an ad-hoc signature by setting the codesigning identity to `-`. macOS seems to want *some* code signature when opening an app from a DMG, a generic ad-hoc one will suffice.

This should once again allow users to open the app by simply right clicking and selecting open instead of needing the terminal workaround.
