### PR TITLE
VERA/ZSM: remember last sample played so that async pitch changes work on ZSM export

### DIFF
--- a/src/engine/platform/vera.cpp
+++ b/src/engine/platform/vera.cpp
@@ -144,6 +144,7 @@ void DivPlatformVERA::reset() {
   }
   chan[16].vol=15;
   chan[16].pan=3;
+  lastCenterRate=-1;
 }
 
 int DivPlatformVERA::calcNoteFreq(int ch, int note) {
@@ -226,9 +227,9 @@ void DivPlatformVERA::tick(bool sysTick) {
     double off=65536.0;
     if (chan[16].pcm.sample>=0 && chan[16].pcm.sample<parent->song.sampleLen) {
       DivSample* s=parent->getSample(chan[16].pcm.sample);
+      lastCenterRate=s->centerRate;
       if (s->centerRate>=1) {
         off=65536.0*(s->centerRate/8363.0);
-        lastCenterRate=s->centerRate;
       }
     } else if (lastCenterRate>=1) {
       off=65536.0*(lastCenterRate/8363.0);
@@ -530,7 +531,6 @@ int DivPlatformVERA::init(DivEngine* p, int channels, int sugRate, const DivConf
   pcm=new struct VERA_PCM;
   dumpWrites=false;
   skipRegisterWrites=false;
-  lastCenterRate=-1;
   setFlags(flags);
   reset();
   return 17;

--- a/src/engine/platform/vera.cpp
+++ b/src/engine/platform/vera.cpp
@@ -230,7 +230,12 @@ void DivPlatformVERA::tick(bool sysTick) {
         off=65536.0;
       } else {
         off=65536.0*(s->centerRate/8363.0);
+        lastCenterRate=s->centerRate;
       }
+    } else if (lastCenterRate<1) {
+      off=65536.0;
+    } else {
+      off=65536.0*(lastCenterRate/8363.0);
     }
     chan[16].freq=parent->calcFreq(chan[16].baseFreq,chan[16].pitch,chan[16].fixedArp?chan[16].baseNoteOverride:chan[16].arpOff,chan[16].fixedArp,false,8,chan[16].pitch2,chipClock,off);
     if (chan[16].freq>128) chan[16].freq=128;
@@ -529,6 +534,7 @@ int DivPlatformVERA::init(DivEngine* p, int channels, int sugRate, const DivConf
   pcm=new struct VERA_PCM;
   dumpWrites=false;
   skipRegisterWrites=false;
+  lastCenterRate=-1;
   setFlags(flags);
   reset();
   return 17;

--- a/src/engine/platform/vera.cpp
+++ b/src/engine/platform/vera.cpp
@@ -226,15 +226,11 @@ void DivPlatformVERA::tick(bool sysTick) {
     double off=65536.0;
     if (chan[16].pcm.sample>=0 && chan[16].pcm.sample<parent->song.sampleLen) {
       DivSample* s=parent->getSample(chan[16].pcm.sample);
-      if (s->centerRate<1) {
-        off=65536.0;
-      } else {
+      if (s->centerRate>=1) {
         off=65536.0*(s->centerRate/8363.0);
         lastCenterRate=s->centerRate;
       }
-    } else if (lastCenterRate<1) {
-      off=65536.0;
-    } else {
+    } else if (lastCenterRate>=1) {
       off=65536.0*(lastCenterRate/8363.0);
     }
     chan[16].freq=parent->calcFreq(chan[16].baseFreq,chan[16].pitch,chan[16].fixedArp?chan[16].baseNoteOverride:chan[16].arpOff,chan[16].fixedArp,false,8,chan[16].pitch2,chipClock,off);

--- a/src/engine/platform/vera.h
+++ b/src/engine/platform/vera.h
@@ -54,6 +54,7 @@ class DivPlatformVERA: public DivDispatch {
     unsigned char regPool[69];
     struct VERA_PSG* psg;
     struct VERA_PCM* pcm;
+    int lastCenterRate;
   
     int calcNoteFreq(int ch, int note);
     friend void putDispatchChip(void*,int);


### PR DESCRIPTION
Prior to this PR, doing slides/portamento/E5xx effects/legato on the VERA PCM channel would export the incorrect pitch because of the way ZSM export works.  PCM events on ZSM export are consumed on the tick that they start, so on export, pitch changes did not know which sample was playing and the divisor ended up being the default 65536.

Remembering the last `s->centerRate` and using its value if there's no sample playing seems like a workable fix, but I'm not sure if it's the best fix.