### PR TITLE
Fix default XY oscilloscope size

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1038,7 +1038,7 @@ Collapsed=0\n\
 \n\
 [Window][Oscilloscope (X-Y)]\n\
 Pos=60,60\n\
-Size=128,128\n\
+Size=300,300\n\
 Collapsed=0\n\
 \n\
 [Docking][Data]\n\

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1036,6 +1036,11 @@ Pos=60,60\n\
 Size=145,184\n\
 Collapsed=0\n\
 \n\
+[Window][Oscilloscope (X-Y)]\n\
+Pos=60,60\n\
+Size=128,128\n\
+Collapsed=0\n\
+\n\
 [Docking][Data]\n\
 DockSpace             ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,24 Size=1280,776 Split=Y Selected=0x6C01C512\n\
   DockNode            ID=0x00000001 Parent=0x8B93E3BD SizeRef=1280,217 Split=X Selected=0xF3094A52\n\

--- a/src/gui/xyOsc.cpp
+++ b/src/gui/xyOsc.cpp
@@ -30,7 +30,7 @@ void FurnaceGUI::drawXYOsc() {
     nextWindow=GUI_WINDOW_NOTHING;
   }
   if (!xyOscOpen) return;
-  ImGui::SetNextWindowSizeConstraints(ImVec2(300.0f*dpiScale,300.0f*dpiScale),ImVec2(canvasW,canvasH));
+  ImGui::SetNextWindowSizeConstraints(ImVec2(128.0f*dpiScale,128.0f*dpiScale),ImVec2(canvasW,canvasH));
   bool noPadding=settings.oscTakesEntireWindow && !xyOscOptions;
   if (noPadding) {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,ImVec2(0,0));

--- a/src/gui/xyOsc.cpp
+++ b/src/gui/xyOsc.cpp
@@ -30,7 +30,7 @@ void FurnaceGUI::drawXYOsc() {
     nextWindow=GUI_WINDOW_NOTHING;
   }
   if (!xyOscOpen) return;
-  ImGui::SetNextWindowSizeConstraints(ImVec2(64.0f*dpiScale,32.0f*dpiScale),ImVec2(canvasW,canvasH));
+  ImGui::SetNextWindowSizeConstraints(ImVec2(300.0f*dpiScale,300.0f*dpiScale),ImVec2(canvasW,canvasH));
   bool noPadding=settings.oscTakesEntireWindow && !xyOscOptions;
   if (noPadding) {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,ImVec2(0,0));


### PR DESCRIPTION
Put a restriction on XY oscilloscope window size so the minimal size now is more than several pixels lol

You may tweak the numbers because I am on 4k screen and that's how in looks good for me