### PR TITLE
macOS: added/modified default keyboard shortcuts

### DIFF
--- a/src/gui/guiConst.cpp
+++ b/src/gui/guiConst.cpp
@@ -538,11 +538,11 @@ const FurnaceGUIActionDef guiActions[GUI_ACTION_MAX]={
   D("SAVE", "Save file", FURKMOD_CMD|SDLK_s),
   D("SAVE_AS", "Save as", FURKMOD_CMD|FURKMOD_SHIFT|SDLK_s),
   D("UNDO", "Undo", FURKMOD_CMD|SDLK_z),
-  #ifdef __APPLE__
+#ifdef __APPLE__
   D("REDO", "Redo", FURKMOD_CMD|FURKMOD_SHIFT|SDLK_z),
-  #else
+#else
   D("REDO", "Redo", FURKMOD_CMD|SDLK_y),
-  #endif
+#endif
   D("PLAY_TOGGLE", "Play/Stop (toggle)", SDLK_RETURN),
   D("PLAY", "Play", 0),
   D("STOP", "Stop", 0),
@@ -578,11 +578,11 @@ const FurnaceGUIActionDef guiActions[GUI_ACTION_MAX]={
   D("WINDOW_SAMPLE_LIST", "Sample List", 0),
   D("WINDOW_SAMPLE_EDIT", "Sample Editor", 0),
   D("WINDOW_ABOUT", "About", 0),
-  #ifdef __APPLE__
+#ifdef __APPLE__
   D("WINDOW_SETTINGS", "Settings", FURKMOD_CMD|SDLK_COMMA),
-  #else
+#else
   D("WINDOW_SETTINGS", "Settings", 0),
-  #endif
+#endif
   D("WINDOW_MIXER", "Mixer", 0),
   D("WINDOW_DEBUG", "Debug Menu", FURKMOD_CMD|FURKMOD_SHIFT|SDLK_d),
   D("WINDOW_OSCILLOSCOPE", "Oscilloscope (master)", 0),

--- a/src/gui/guiConst.cpp
+++ b/src/gui/guiConst.cpp
@@ -538,7 +538,11 @@ const FurnaceGUIActionDef guiActions[GUI_ACTION_MAX]={
   D("SAVE", "Save file", FURKMOD_CMD|SDLK_s),
   D("SAVE_AS", "Save as", FURKMOD_CMD|FURKMOD_SHIFT|SDLK_s),
   D("UNDO", "Undo", FURKMOD_CMD|SDLK_z),
+  #ifdef __APPLE__
+  D("REDO", "Redo", FURKMOD_CMD|FURKMOD_SHIFT|SDLK_z),
+  #else
   D("REDO", "Redo", FURKMOD_CMD|SDLK_y),
+  #endif
   D("PLAY_TOGGLE", "Play/Stop (toggle)", SDLK_RETURN),
   D("PLAY", "Play", 0),
   D("STOP", "Stop", 0),
@@ -574,7 +578,11 @@ const FurnaceGUIActionDef guiActions[GUI_ACTION_MAX]={
   D("WINDOW_SAMPLE_LIST", "Sample List", 0),
   D("WINDOW_SAMPLE_EDIT", "Sample Editor", 0),
   D("WINDOW_ABOUT", "About", 0),
+  #ifdef __APPLE__
+  D("WINDOW_SETTINGS", "Settings", FURKMOD_CMD|SDLK_COMMA),
+  #else
   D("WINDOW_SETTINGS", "Settings", 0),
+  #endif
   D("WINDOW_MIXER", "Mixer", 0),
   D("WINDOW_DEBUG", "Debug Menu", FURKMOD_CMD|FURKMOD_SHIFT|SDLK_d),
   D("WINDOW_OSCILLOSCOPE", "Oscilloscope (master)", 0),


### PR DESCRIPTION
Added `Cmd-,` for "Settings" and `Cmd-Shift-Z` for "Redo" to match recommended defaults for Mac apps.
Built and tested with no errors.

Note: Will only take effect for new installations / if no config files are found.