### PR TITLE
Matches preview playback with midi volume input when enabled

### DIFF
--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -1825,37 +1825,37 @@ void DivEngine::nextBuf(float** in, float** out, int inChans, int outChans, unsi
     if ((ins=midiCallback(msg))!=-2) {
       int chan=msg.type&15;
       switch (msg.type&0xf0) {
-        // case TA_MIDI_NOTE_OFF: {
-        //   if (chan<0 || chan>=chans) break;
-        //   if (midiIsDirect) {
-        //     pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
-        //   } else {
-        //     autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
-        //   }
-        //   if (!playing) {
-        //     reset();
-        //     freelance=true;
-        //     playing=true;
-        //   }
-        //   break;
-        // }
-        // case TA_MIDI_NOTE_ON: {
-        //   if (chan<0 || chan>=chans) break;
-        //   if (msg.data[1]==0) {
-        //     if (midiIsDirect) {
-        //       pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
-        //     } else {
-        //       autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
-        //     }
-        //   } else {
-        //     if (midiIsDirect) {
-        //       pendingNotes.push_back(DivNoteEvent(chan,ins,msg.data[0]-12,msg.data[1],true));
-        //     } else {
-        //       autoNoteOn(msg.type&15,ins,msg.data[0]-12,msg.data[1]);
-        //     }
-        //   }
-        //   break;
-        // }
+        case TA_MIDI_NOTE_OFF: {
+          if (chan<0 || chan>=chans) break;
+          if (midiIsDirect) {
+            pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
+          } else {
+            autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
+          }
+          if (!playing) {
+            reset();
+            freelance=true;
+            playing=true;
+          }
+          break;
+        }
+        case TA_MIDI_NOTE_ON: {
+          if (chan<0 || chan>=chans) break;
+          if (msg.data[1]==0) {
+            if (midiIsDirect) {
+              pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
+            } else {
+              autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
+            }
+          } else {
+            if (midiIsDirect) {
+              pendingNotes.push_back(DivNoteEvent(chan,ins,msg.data[0]-12,msg.data[1],true));
+            } else {
+              autoNoteOn(msg.type&15,ins,msg.data[0]-12,msg.data[1]);
+            }
+          }
+          break;
+        }
         case TA_MIDI_PROGRAM: {
           // TODO: change instrument event thingy
           break;

--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -1372,7 +1372,7 @@ bool DivEngine::nextTick(bool noAccum, bool inhibitLowLat) {
     }
     if (note.on) {
       dispatchCmd(DivCommand(DIV_CMD_INSTRUMENT,note.channel,note.ins,1));
-      //dispatchCmd(DivCommand(DIV_CMD_VOLUME,note.channel,(note.volume*(chan[note.channel].volMax>>8))/127));
+      dispatchCmd(DivCommand(DIV_CMD_VOLUME,note.channel,(note.volume * (chan[note.channel].volMax>>8)) / 127));
       dispatchCmd(DivCommand(DIV_CMD_NOTE_ON,note.channel,note.note));
       keyHit[note.channel]=true;
       chan[note.channel].releasing=false;

--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -1825,37 +1825,37 @@ void DivEngine::nextBuf(float** in, float** out, int inChans, int outChans, unsi
     if ((ins=midiCallback(msg))!=-2) {
       int chan=msg.type&15;
       switch (msg.type&0xf0) {
-        case TA_MIDI_NOTE_OFF: {
-          if (chan<0 || chan>=chans) break;
-          if (midiIsDirect) {
-            pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
-          } else {
-            autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
-          }
-          if (!playing) {
-            reset();
-            freelance=true;
-            playing=true;
-          }
-          break;
-        }
-        case TA_MIDI_NOTE_ON: {
-          if (chan<0 || chan>=chans) break;
-          if (msg.data[1]==0) {
-            if (midiIsDirect) {
-              pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
-            } else {
-              autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
-            }
-          } else {
-            if (midiIsDirect) {
-              pendingNotes.push_back(DivNoteEvent(chan,ins,msg.data[0]-12,msg.data[1],true));
-            } else {
-              autoNoteOn(msg.type&15,ins,msg.data[0]-12,msg.data[1]);
-            }
-          }
-          break;
-        }
+        // case TA_MIDI_NOTE_OFF: {
+        //   if (chan<0 || chan>=chans) break;
+        //   if (midiIsDirect) {
+        //     pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
+        //   } else {
+        //     autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
+        //   }
+        //   if (!playing) {
+        //     reset();
+        //     freelance=true;
+        //     playing=true;
+        //   }
+        //   break;
+        // }
+        // case TA_MIDI_NOTE_ON: {
+        //   if (chan<0 || chan>=chans) break;
+        //   if (msg.data[1]==0) {
+        //     if (midiIsDirect) {
+        //       pendingNotes.push_back(DivNoteEvent(chan,-1,-1,-1,false));
+        //     } else {
+        //       autoNoteOff(msg.type&15,msg.data[0]-12,msg.data[1]);
+        //     }
+        //   } else {
+        //     if (midiIsDirect) {
+        //       pendingNotes.push_back(DivNoteEvent(chan,ins,msg.data[0]-12,msg.data[1],true));
+        //     } else {
+        //       autoNoteOn(msg.type&15,ins,msg.data[0]-12,msg.data[1]);
+        //     }
+        //   }
+        //   break;
+        // }
         case TA_MIDI_PROGRAM: {
           // TODO: change instrument event thingy
           break;

--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -1372,7 +1372,7 @@ bool DivEngine::nextTick(bool noAccum, bool inhibitLowLat) {
     }
     if (note.on) {
       dispatchCmd(DivCommand(DIV_CMD_INSTRUMENT,note.channel,note.ins,1));
-      dispatchCmd(DivCommand(DIV_CMD_VOLUME,note.channel,(note.volume * (chan[note.channel].volMax>>8)) / 127));
+      dispatchCmd(DivCommand(DIV_CMD_VOLUME,note.channel,(note.volume*(chan[note.channel].volMax>>8))/127));
       dispatchCmd(DivCommand(DIV_CMD_NOTE_ON,note.channel,note.note));
       keyHit[note.channel]=true;
       chan[note.channel].releasing=false;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -3767,10 +3767,6 @@ bool FurnaceGUI::loop() {
         learning=-1;
       } else {
         int action=midiMap.at(msg);
-        int chan=msg.type&15;
-        int ins=-1;
-        int vol = midiMap.volInput?((int)(pow((double)msg.data[1]/127.0,midiMap.volExp)*127.0)):-1;
-        int note = msg.data[0]-12;
         if (action!=0) {
           doAction(action);
         } else switch (msg.type&0xf0) {
@@ -3778,33 +3774,10 @@ bool FurnaceGUI::loop() {
             if (midiMap.valueInputStyle==0 || midiMap.valueInputStyle>3 || cursor.xFine==0) {
               if (midiMap.noteInput && edit && msg.data[1]!=0) {
                 noteInput(
-                  note,
+                  msg.data[0]-12,
                   0,
-                  vol
+                  midiMap.volInput?((int)(pow((double)msg.data[1]/127.0,midiMap.volExp)*127.0)):-1
                 );
-                // Preview note input with velocity sensitivity
-                if (midiMap.directChannel) {
-                  e->noteOn(
-                    chan,
-                    ins,
-                    note,
-                    vol
-                  );
-                } else {
-                  e->autoNoteOn(
-                    chan,
-                    ins,
-                    note,
-                    vol
-                  );
-                }
-              } else if (msg.data[1]==0) {
-                // Velocity 0 note offs
-                if (midiMap.directChannel) {
-                  e->noteOff(chan);
-                } else {
-                  e->autoNoteOff(chan, note);
-                }  
               }
             } else {
               if (edit && msg.data[1]!=0) {
@@ -3829,13 +3802,6 @@ bool FurnaceGUI::loop() {
               }
             }
             break;
-          case TA_MIDI_NOTE_OFF:
-            if (midiMap.directChannel) {
-              e->noteOff(msg.type&15);
-            } else {
-              e->autoNoteOff(msg.type&15, msg.data[0]-12);
-            }  
-            break;    
           case TA_MIDI_PROGRAM:
             if (midiMap.programChange) {
               curIns=msg.data[0];

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -3767,6 +3767,10 @@ bool FurnaceGUI::loop() {
         learning=-1;
       } else {
         int action=midiMap.at(msg);
+        int chan=msg.type&15;
+        int ins=-1;
+        int vol = midiMap.volInput?((int)(pow((double)msg.data[1]/127.0,midiMap.volExp)*127.0)):-1;
+        int note = msg.data[0]-12;
         if (action!=0) {
           doAction(action);
         } else switch (msg.type&0xf0) {
@@ -3774,10 +3778,33 @@ bool FurnaceGUI::loop() {
             if (midiMap.valueInputStyle==0 || midiMap.valueInputStyle>3 || cursor.xFine==0) {
               if (midiMap.noteInput && edit && msg.data[1]!=0) {
                 noteInput(
-                  msg.data[0]-12,
+                  note,
                   0,
-                  midiMap.volInput?((int)(pow((double)msg.data[1]/127.0,midiMap.volExp)*127.0)):-1
+                  vol
                 );
+                // Preview note input with velocity sensitivity
+                if (midiMap.directChannel) {
+                  e->noteOn(
+                    chan,
+                    ins,
+                    note,
+                    vol
+                  );
+                } else {
+                  e->autoNoteOn(
+                    chan,
+                    ins,
+                    note,
+                    vol
+                  );
+                }
+              } else if (msg.data[1]==0) {
+                // Velocity 0 note offs
+                if (midiMap.directChannel) {
+                  e->noteOff(chan);
+                } else {
+                  e->autoNoteOff(chan, note);
+                }  
               }
             } else {
               if (edit && msg.data[1]!=0) {
@@ -3802,6 +3829,13 @@ bool FurnaceGUI::loop() {
               }
             }
             break;
+          case TA_MIDI_NOTE_OFF:
+            if (midiMap.directChannel) {
+              e->noteOff(msg.type&15);
+            } else {
+              e->autoNoteOff(msg.type&15, msg.data[0]-12);
+            }  
+            break;    
           case TA_MIDI_PROGRAM:
             if (midiMap.programChange) {
               curIns=msg.data[0];


### PR DESCRIPTION
## What
Enable velocity sensitive preview for midi in


## Why
The midi in velocity sensitivity feature is currently awkward to use since you can't hear how loud the note will be when you press it. Making the preview match what will be played back makes the feature easier to use 

## How
~~Uncommented line which enables midi input preview playback. The commented out line was added in a commit with a nonsense message so not sure what the intention was / why it was commented out.~~

Moved all note message processing to GUI so that the playback has access to the midi settings. 

## Testing

~~Tested with a few chip and logged calculated, the results match what goes into the column.
On Genesis a lot of the range is super quiet but that's how it is.
NES maps to the correct range (volume of 1 is kinda hard to hit on my controller but it's possible)
C64 also maps to the correct range (even though the chip has special restrictions on how volume works).~~

After revising the Genesis playback feels more natural

## Notes for reviewer
Is there a reason this was commented out that needs to be handled differently?



   

