### PR TITLE
Add initial support for SAP type R POKEY export.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ src/engine/pattern.cpp
 src/engine/pitchTable.cpp
 src/engine/playback.cpp
 src/engine/sample.cpp
+src/engine/saprOps.cpp
 src/engine/song.cpp
 src/engine/sysDef.cpp
 src/engine/wavetable.cpp

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -648,7 +648,7 @@ class DivEngine {
     // dump to ZSM.
     SafeWriter* saveZSM(unsigned int zsmrate=60, bool loop=true, bool optimize=true);
     // dump to SAP-R.
-    SafeWriter* saveSAPR(int sapScanlines=0, bool palTiming=true);
+    SafeWriter* saveSAPR(int sapScanlines=0);
     // dump command stream.
     SafeWriter* saveCommand(bool binary=false);
     // export to text

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -647,6 +647,8 @@ class DivEngine {
     SafeWriter* saveVGM(bool* sysToExport=NULL, bool loop=true, int version=0x171, bool patternHints=false, bool directStream=false, int trailingTicks=-1);
     // dump to ZSM.
     SafeWriter* saveZSM(unsigned int zsmrate=60, bool loop=true, bool optimize=true);
+    // dump to SAP-R.
+    SafeWriter* saveSAPR(int sapScanlines=0, bool palTiming=true);
     // dump command stream.
     SafeWriter* saveCommand(bool binary=false);
     // export to text

--- a/src/engine/saprOps.cpp
+++ b/src/engine/saprOps.cpp
@@ -39,7 +39,7 @@ static std::string ticksToTime(double rate, int ticks) {
   );
 }
 
-SafeWriter* DivEngine::saveSAPR(int sapScanlines, bool palTiming) {
+SafeWriter* DivEngine::saveSAPR(int sapScanlines) {
   int POKEY=-1;
   int IGNORED=0;
 
@@ -73,6 +73,7 @@ SafeWriter* DivEngine::saveSAPR(int sapScanlines, bool palTiming) {
   setOrder(0);
   BUSY_BEGIN_SOFT;
 
+  bool palTiming = song.systemFlags[POKEY].getInt("clockSel",0) != 0;
   int scanlinesPerFrame = (palTiming?312:262);
   if (sapScanlines <= 0) {
     sapScanlines = scanlinesPerFrame;
@@ -150,7 +151,7 @@ SafeWriter* DivEngine::saveSAPR(int sapScanlines, bool palTiming) {
   extValuePresent=false;
 
   auto w = new SafeWriter;
-  w->init();
+  w->init(); 
   // Write SAP header: Author, name, timing, type.
   w->writeText(fmt::sprintf("SAP\r\nAUTHOR \"%s\"\r\nNAME\"%s\"\r\n%s\r\nTYPE R\r\n",
     song.author, song.name, palTiming ? "PAL" : "NTSC"

--- a/src/engine/saprOps.cpp
+++ b/src/engine/saprOps.cpp
@@ -1,0 +1,172 @@
+/**
+ * Furnace Tracker - multi-system chiptune tracker
+ * Copyright (C) 2021-2024 tildearrow and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "engine.h"
+#include "../ta-log.h"
+#include "../utfutils.h"
+#include "safeWriter.h"
+#include "song.h"
+#include <fmt/printf.h>
+#include <array>
+#include <vector>
+
+constexpr int MASTER_CLOCK_PREC=(sizeof(void*)==8)?8:0;
+constexpr int MASTER_CLOCK_MASK=(sizeof(void*)==8)?0xff:0;
+
+static std::string ticksToTime(double rate, int ticks) {
+  double timing = ticks / rate;
+
+  return fmt::sprintf("%02d:%02d.%03d",
+    (int) timing / 60,
+    (int) timing % 60,
+    (int) (timing * 1000) % 1000
+  );
+}
+
+SafeWriter* DivEngine::saveSAPR(int sapScanlines, bool palTiming) {
+  int POKEY=-1;
+  int IGNORED=0;
+
+  // Locate system index.
+  for (int i=0; i<song.systemLen; i++) {
+    if (song.system[i] == DIV_SYSTEM_POKEY) {
+        if (POKEY>=0) {
+          IGNORED++;
+          logD("Ignoring duplicate POKEY id %d",i);
+          break;
+        }
+        POKEY=i;
+        logD("POKEY detected as chip id %d",i);
+        break;
+    } else {
+      IGNORED++;
+      logD("Ignoring chip id %d, system id %d",i,(int)song.system[i]);
+      break;
+    }
+  }
+  if (POKEY<0) {
+    logE("Could not find POKEY");
+    return NULL;
+  }
+  if (IGNORED>0) {
+    logW("SAP export ignoring %d unsupported system%c",IGNORED,IGNORED>1?'s':' ');
+  }
+
+  stop();
+  repeatPattern=false;
+  setOrder(0);
+  BUSY_BEGIN_SOFT;
+
+  int scanlinesPerFrame = (palTiming?312:262);
+  if (sapScanlines <= 0) {
+    sapScanlines = scanlinesPerFrame;
+  }
+  double origRate = got.rate;
+  double sapRate = (palTiming?49.86:59.92) * scanlinesPerFrame / sapScanlines;;
+  got.rate=sapRate;
+
+  // Determine loop point.
+  int loopOrder=0;
+  int loopRow=0;
+  int loopEnd=0;
+  walkSong(loopOrder,loopRow,loopEnd);
+  logI("loop point: %d %d",loopOrder,loopRow);
+  warnings="";
+
+  // Reset the playback state.
+  curOrder=0;
+  freelance=false;
+  playing=false;
+  extValuePresent=false;
+  remainingLoops=-1;
+
+  // Prepare to write song data.
+  playSub(false);
+  size_t tickCount=0;
+  bool done=false;
+  int fracWait=0; // accumulates fractional ticks
+  disCont[POKEY].dispatch->toggleRegisterDump(true);
+
+  std::vector<std::array<uint8_t, 9>> regs;
+  std::array<uint8_t, 9> currRegs;
+
+  while (!done) {
+    if (nextTick() || !playing) {
+      done=true;
+      for (int i=0; i<song.systemLen; i++) {
+        disCont[i].dispatch->getRegisterWrites().clear();
+      }
+      break;
+    }
+    // get register dumps
+    std::vector<DivRegWrite>& writes=disCont[POKEY].dispatch->getRegisterWrites();
+    if (writes.size() > 0) {
+      logD("saprOps: found %d messages",writes.size());
+      for (DivRegWrite& write: writes)
+        if ((write.addr & 0xF) < 9)
+          currRegs[write.addr & 0xF] = write.val;
+      writes.clear();
+    }
+
+    // write wait
+    tickCount++;
+    int totalWait=cycles>>MASTER_CLOCK_PREC;
+    fracWait+=cycles&MASTER_CLOCK_MASK;
+    totalWait+=fracWait>>MASTER_CLOCK_PREC;
+    fracWait&=MASTER_CLOCK_MASK;
+    if (totalWait>0 && !done) {
+      while (totalWait) {
+        regs.push_back(currRegs);
+        totalWait--;
+        tickCount++;
+      }
+    }
+  }
+  // end of song
+
+  // done - close out.
+  got.rate=origRate;
+  disCont[POKEY].dispatch->toggleRegisterDump(false);
+
+  remainingLoops=-1;
+  playing=false;
+  freelance=false;
+  extValuePresent=false;
+
+  auto w = new SafeWriter;
+  w->init();
+  // Write SAP header: Author, name, timing, type.
+  w->writeText(fmt::sprintf("SAP\r\nAUTHOR \"%s\"\r\nNAME\"%s\"\r\n%s\r\nTYPE R\r\n",
+    song.author, song.name, palTiming ? "PAL" : "NTSC"
+  ));
+  if (sapScanlines != scanlinesPerFrame) {
+    // Fastplay.
+    w->writeText(fmt::sprintf("FASTPLAY %d\r\n", sapScanlines));
+  }
+  // Time.
+  w->writeText(fmt::sprintf("TIME %s\r\n", ticksToTime(sapRate, tickCount)));
+  w->writeText("\r\n");
+  // Registers.
+  for (auto atRegs : regs) {
+    w->write(atRegs.data(), 9 * sizeof(uint8_t));
+  }
+
+  BUSY_END;
+  return w;
+}

--- a/src/engine/saprOps.cpp
+++ b/src/engine/saprOps.cpp
@@ -79,7 +79,8 @@ SafeWriter* DivEngine::saveSAPR(int sapScanlines) {
     sapScanlines = scanlinesPerFrame;
   }
   double origRate = got.rate;
-  double sapRate = (palTiming?49.86:59.92) * scanlinesPerFrame / sapScanlines;;
+  //double sapRate = (palTiming?49.86:59.92) * scanlinesPerFrame / sapScanlines;
+  double sapRate = (palTiming?50:60) * scanlinesPerFrame / sapScanlines;
   got.rate=sapRate;
 
   // Determine loop point.

--- a/src/engine/saprOps.cpp
+++ b/src/engine/saprOps.cpp
@@ -153,7 +153,7 @@ SafeWriter* DivEngine::saveSAPR(int sapScanlines) {
   auto w = new SafeWriter;
   w->init(); 
   // Write SAP header: Author, name, timing, type.
-  w->writeText(fmt::sprintf("SAP\r\nAUTHOR \"%s\"\r\nNAME\"%s\"\r\n%s\r\nTYPE R\r\n",
+  w->writeText(fmt::sprintf("SAP\r\nAUTHOR \"%s\"\r\nNAME \"%s\"\r\n%s\r\nTYPE R\r\n",
     song.author, song.name, palTiming ? "PAL" : "NTSC"
   ));
   if (sapScanlines != scanlinesPerFrame) {

--- a/src/gui/exportOptions.cpp
+++ b/src/gui/exportOptions.cpp
@@ -176,6 +176,21 @@ void FurnaceGUI::drawExportZSM(bool onWindow) {
   }
 }
 
+void FurnaceGUI::drawExportSAPR(bool onWindow) {
+  exitDisabledTimer=1;
+
+  ImGui::Checkbox("use PAL timings",&saprExportPal);
+  if (onWindow) {
+    ImGui::Separator();
+    if (ImGui::Button("Cancel",ImVec2(200.0f*dpiScale,0))) ImGui::CloseCurrentPopup();
+    ImGui::SameLine();
+  }
+  if (ImGui::Button("Export",ImVec2(200.0f*dpiScale,0))) {
+    openFileDialog(GUI_FILE_EXPORT_SAPR);
+    ImGui::CloseCurrentPopup();
+  }
+}
+
 void FurnaceGUI::drawExportAmigaVal(bool onWindow) {
   exitDisabledTimer=1;
 
@@ -268,8 +283,12 @@ void FurnaceGUI::drawExport() {
         ImGui::EndTabItem();
       }
       int numZSMCompat=0;
+      int numSAPRCompat=0;
+      int numAmiga=0;
       for (int i=0; i<e->song.systemLen; i++) {
         if ((e->song.system[i]==DIV_SYSTEM_VERA) || (e->song.system[i]==DIV_SYSTEM_YM2151)) numZSMCompat++;
+        if (e->song.system[i]==DIV_SYSTEM_POKEY) numSAPRCompat++;
+        if (e->song.system[i]==DIV_SYSTEM_AMIGA) numAmiga++;
       }
       if (numZSMCompat>0) {
         if (ImGui::BeginTabItem("ZSM")) {
@@ -277,9 +296,11 @@ void FurnaceGUI::drawExport() {
           ImGui::EndTabItem();
         }
       }
-      int numAmiga=0;
-      for (int i=0; i<e->song.systemLen; i++) {
-        if (e->song.system[i]==DIV_SYSTEM_AMIGA) numAmiga++;
+      if (numSAPRCompat>0) {
+        if (ImGui::BeginTabItem("SAP-R")) {
+          drawExportSAPR(true);
+          ImGui::EndTabItem();
+        }
       }
       if (numAmiga && settings.iCannotWait) {
         if (ImGui::BeginTabItem("Amiga Validation")) {
@@ -306,6 +327,9 @@ void FurnaceGUI::drawExport() {
       break;
     case GUI_EXPORT_ZSM:
       drawExportZSM(true);
+      break;
+    case GUI_EXPORT_SAPR:
+      drawExportSAPR(true);
       break;
     case GUI_EXPORT_AMIGA_VAL:
       drawExportAmigaVal(true);

--- a/src/gui/exportOptions.cpp
+++ b/src/gui/exportOptions.cpp
@@ -179,7 +179,6 @@ void FurnaceGUI::drawExportZSM(bool onWindow) {
 void FurnaceGUI::drawExportSAPR(bool onWindow) {
   exitDisabledTimer=1;
 
-  ImGui::Checkbox("use PAL timings",&saprExportPal);
   if (onWindow) {
     ImGui::Separator();
     if (ImGui::Button("Cancel",ImVec2(200.0f*dpiScale,0))) ImGui::CloseCurrentPopup();

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -5233,7 +5233,7 @@ bool FurnaceGUI::loop() {
               break;
             }
             case GUI_FILE_EXPORT_SAPR: {
-              SafeWriter* w=e->saveSAPR(0, saprExportPal);
+              SafeWriter* w=e->saveSAPR(0);
               if (w!=NULL) {
                 FILE* f=ps_fopen(copyOfName.c_str(),"wb");
                 if (f!=NULL) {
@@ -7249,7 +7249,6 @@ FurnaceGUI::FurnaceGUI():
   vgmExportTrailingTicks(-1),
   drawHalt(10),
   zsmExportTickRate(60),
-  saprExportPal(true),
   macroPointSize(16),
   waveEditStyle(0),
   displayInsTypeListMakeInsSample(-1),

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1482,7 +1482,6 @@ class FurnaceGUI {
   int vgmExportTrailingTicks;
   int drawHalt;
   int zsmExportTickRate;
-  bool saprExportPal;
   int macroPointSize;
   int waveEditStyle;
   int displayInsTypeListMakeInsSample;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -172,6 +172,7 @@ enum FurnaceGUIColors {
   GUI_COLOR_FILE_WAVE,
   GUI_COLOR_FILE_VGM,
   GUI_COLOR_FILE_ZSM,
+  GUI_COLOR_FILE_SAPR,
   GUI_COLOR_FILE_FONT,
   GUI_COLOR_FILE_OTHER,
 
@@ -510,6 +511,7 @@ enum FurnaceGUIFileDialogs {
   GUI_FILE_EXPORT_AUDIO_PER_CHANNEL,
   GUI_FILE_EXPORT_VGM,
   GUI_FILE_EXPORT_ZSM,
+  GUI_FILE_EXPORT_SAPR,
   GUI_FILE_EXPORT_CMDSTREAM,
   GUI_FILE_EXPORT_CMDSTREAM_BINARY,
   GUI_FILE_EXPORT_TEXT,
@@ -557,6 +559,7 @@ enum FurnaceGUIExportTypes {
   GUI_EXPORT_AUDIO=0,
   GUI_EXPORT_VGM,
   GUI_EXPORT_ZSM,
+  GUI_EXPORT_SAPR,
   GUI_EXPORT_CMD_STREAM,
   GUI_EXPORT_AMIGA_VAL,
   GUI_EXPORT_TEXT
@@ -1448,7 +1451,7 @@ class FurnaceGUI {
 
   String workingDir, fileName, clipboard, warnString, errorString, lastError, curFileName, nextFile, sysSearchQuery, newSongQuery;
   String workingDirSong, workingDirIns, workingDirWave, workingDirSample, workingDirAudioExport;
-  String workingDirVGMExport, workingDirZSMExport, workingDirROMExport, workingDirFont, workingDirColors, workingDirKeybinds;
+  String workingDirVGMExport, workingDirZSMExport, workingDirSAPRExport, workingDirROMExport, workingDirFont, workingDirColors, workingDirKeybinds;
   String workingDirLayout, workingDirROM, workingDirTest;
   String mmlString[32];
   String mmlStringW, grooveString, grooveListString, mmlStringModTable;
@@ -1479,6 +1482,7 @@ class FurnaceGUI {
   int vgmExportTrailingTicks;
   int drawHalt;
   int zsmExportTickRate;
+  bool saprExportPal;
   int macroPointSize;
   int waveEditStyle;
   int displayInsTypeListMakeInsSample;
@@ -2379,6 +2383,7 @@ class FurnaceGUI {
   void drawExportAudio(bool onWindow=false);
   void drawExportVGM(bool onWindow=false);
   void drawExportZSM(bool onWindow=false);
+  void drawExportSAPR(bool onWindow=false);
   void drawExportAmigaVal(bool onWindow=false);
   void drawExportText(bool onWindow=false);
   void drawExportCommand(bool onWindow=false);

--- a/src/gui/guiConst.cpp
+++ b/src/gui/guiConst.cpp
@@ -867,6 +867,7 @@ const FurnaceGUIColorDef guiColors[GUI_COLOR_MAX]={
   D(GUI_COLOR_FILE_WAVE,"",ImVec4(1.0f,0.75f,0.5f,1.0f)),
   D(GUI_COLOR_FILE_VGM,"",ImVec4(1.0f,1.0f,0.5f,1.0f)),
   D(GUI_COLOR_FILE_ZSM,"",ImVec4(1.0f,1.0f,0.5f,1.0f)),
+  D(GUI_COLOR_FILE_SAPR,"",ImVec4(1.0f,1.0f,0.5f,1.0f)),
   D(GUI_COLOR_FILE_FONT,"",ImVec4(0.3f,1.0f,0.6f,1.0f)),
   D(GUI_COLOR_FILE_OTHER,"",ImVec4(0.7f,0.7f,0.7f,1.0f)),
 

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -3352,6 +3352,7 @@ void FurnaceGUI::drawSettings() {
           UI_COLOR_CONFIG(GUI_COLOR_FILE_WAVE,"Wavetable");
           UI_COLOR_CONFIG(GUI_COLOR_FILE_VGM,"VGM");
           UI_COLOR_CONFIG(GUI_COLOR_FILE_ZSM,"ZSM");
+          UI_COLOR_CONFIG(GUI_COLOR_FILE_SAPR,"SAP-R");
           UI_COLOR_CONFIG(GUI_COLOR_FILE_FONT,"Font");
           UI_COLOR_CONFIG(GUI_COLOR_FILE_OTHER,"Other");
           ImGui::TreePop();
@@ -5540,6 +5541,7 @@ void FurnaceGUI::applyUISettings(bool updateFonts) {
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".brr",uiColors[GUI_COLOR_FILE_AUDIO],ICON_FA_FILE_AUDIO_O);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".vgm",uiColors[GUI_COLOR_FILE_VGM],ICON_FA_FILE_AUDIO_O);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".zsm",uiColors[GUI_COLOR_FILE_ZSM],ICON_FA_FILE_AUDIO_O);
+  ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".sap",uiColors[GUI_COLOR_FILE_SAPR],ICON_FA_FILE_AUDIO_O);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".ttf",uiColors[GUI_COLOR_FILE_FONT],ICON_FA_FONT);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".otf",uiColors[GUI_COLOR_FILE_FONT],ICON_FA_FONT);
   ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtension,".ttc",uiColors[GUI_COLOR_FILE_FONT],ICON_FA_FONT);


### PR DESCRIPTION
This format is of increasing interest in the Atari 8-bit scene due to the existence of an [efficient decompression+player routine](https://github.com/dmsc/lzss-sap/) which uses it as input. It's essentially a more bare-bones VGM. The resulting files can also be played directly by the Altirra emulator.

The exporter could probably be improved somewhat (exporting two POKEY chips to two files for stereo playback, for example - an use-case implemented by the [RMT->LZSS converter](https://forums.atariage.com/topic/315537-rmt2lzss-convert-rmt-tunes-to-lzss-for-fast-playback/)), but I've done this as a proof of concept for a friend. In addition, the above-mentioned playroutine's compressor does *not* actually parse the header, and a lot of standalone .SAP players don't handle Type R, so I haven't put much effort into populating it wholly.

Due to the niche usecase, I won't feel sad if it doesn't get merged, don't worry. (However, it could serve as a base for a ROM export functionality for the platform in the future...)