### PR TITLE
GUI: fix overflow in timers

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -3411,7 +3411,7 @@ bool FurnaceGUI::detectOutOfBoundsWindow(SDL_Rect& failing) {
 }
 
 #define DECLARE_METRIC(_n) \
-  int __perfM##_n;
+  uint64_t __perfM##_n;
 
 #define MEASURE_BEGIN(_n) \
   __perfM##_n=SDL_GetPerformanceCounter();

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -27,6 +27,7 @@
 #include "imgui_impl_sdl2.h"
 #include <SDL.h>
 #include <fftw3.h>
+#include <stdint.h>
 #include <initializer_list>
 #include <future>
 #include <memory>
@@ -2162,10 +2163,10 @@ class FurnaceGUI {
   ImVec2 orderScrollRealOrigin;
   ImVec2 dragMobileMenuOrigin;
 
-  int layoutTimeBegin, layoutTimeEnd, layoutTimeDelta;
-  int renderTimeBegin, renderTimeEnd, renderTimeDelta;
-  int drawTimeBegin, drawTimeEnd, drawTimeDelta;
-  int eventTimeBegin, eventTimeEnd, eventTimeDelta;
+  uint64_t layoutTimeBegin, layoutTimeEnd, layoutTimeDelta;
+  uint64_t renderTimeBegin, renderTimeEnd, renderTimeDelta;
+  uint64_t drawTimeBegin, drawTimeEnd, drawTimeDelta;
+  uint64_t eventTimeBegin, eventTimeEnd, eventTimeDelta;
 
   FurnaceGUIPerfMetric perfMetrics[64];
   int perfMetricsLen;


### PR DESCRIPTION
these timer variables are used with [SDL_GetPerformanceCounter](https://wiki.libsdl.org/SDL2/SDL_GetPerformanceCounter), which returns a uint64_t. subtracting these can overflow, which is UB.

---

specifically, with `-fsanitize=signed-integer-overflow` it's somewhat likely to catch this at seemingly random (because the large value stored in int is then a negative number and easily underflows), though nothing super reproducible (caught this because that sanitizer is set by default in something i was working on)