### PR TITLE
Fix OpenMPT clipboard paste (again...)

### DIFF
--- a/src/gui/editing.cpp
+++ b/src/gui/editing.cpp
@@ -1035,7 +1035,7 @@ void FurnaceGUI::doPasteMPT(PasteMode mode, int arg, bool readClipboard, String 
         else 
         {
           unsigned int val=0;
-          if (sscanf(note,"%2X",&val)!=1) 
+          if (sscanf(note,"%2d",&val)!=1) 
           {
             invalidData=true;
             break;
@@ -1043,7 +1043,7 @@ void FurnaceGUI::doPasteMPT(PasteMode mode, int arg, bool readClipboard, String 
 
           if (!(mode==GUI_PASTE_MODE_MIX_BG || mode==GUI_PASTE_MODE_INS_BG) || pat->data[j][iFine+1]==-1) 
           {
-            pat->data[j][iFine+1]=val;
+            pat->data[j][iFine+1]=val - 1;
           }
         }
       }


### PR DESCRIPTION
It uses decimal instrument indices with +1 offset instead of hex as I always thought...