### PR TITLE
Enables volume envelopes in the noise channel of the VSU in VirtualBoy.

### DIFF
--- a/src/engine/platform/vb.cpp
+++ b/src/engine/platform/vb.cpp
@@ -324,7 +324,7 @@ int DivPlatformVB::dispatch(DivCommand c) {
       chan[c.chan].envHigh&=~3;
       chan[c.chan].envHigh|=(c.value>>4)&3;
       chan[c.chan].envLow=c.value&15;
-      writeEnv(c.chan);
+      writeEnv(c.chan,true);
       break;
     case DIV_CMD_FDS_MOD_DEPTH: // set modulation
       if (c.chan!=4) break;


### PR DESCRIPTION
<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->

The current implementation of the noise channel in VirtualBoy prevents the use of volume envelopes (command 12xy). I have checked some original tunes for this platform (e.g. from WarioLand) which feature noise drum tracks with volume envelopes so these should be also featured in the noise channel.

The proposed fix provides `upperByteToo=true` to `writeEnv` when executing the `DIV_CMD_STD_NOISE_FREQ` command. An alternative implementation would change the `writeEnv` function to accept channel 5 too but I was not sure about the implications of this solution.



