### PR TITLE
Fix wayland icon with SDL_VIDEO_WAYLAND_WMCLASS

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -6744,6 +6744,9 @@ bool FurnaceGUI::init() {
   SDL_SetHint(SDL_HINT_X11_WINDOW_TYPE,"_NET_WM_WINDOW_TYPE_NORMAL");
 #endif
 
+  // This sets the icon in wayland
+  SDL_setenv("SDL_VIDEO_WAYLAND_WMCLASS", FURNACE_APP_ID, 0);
+
   // initialize SDL
   logD("initializing video...");
   if (SDL_Init(SDL_INIT_VIDEO)!=0) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -36,6 +36,8 @@
 
 #include "fileDialog.h"
 
+#define FURNACE_APP_ID "org.tildearrow.furnace"
+
 #define rightClickable if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) ImGui::SetKeyboardFocusHere(-1);
 #define ctrlWheeling ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && wheelY!=0)
 


### PR DESCRIPTION
This is used by SDL to set the xdg_toplevel app_id.

![Screenshot from 2024-06-04 11-15-55](https://github.com/tildearrow/furnace/assets/334272/6883f99b-58a2-4d42-a5be-cfe21ccfefc7)
