### PR TITLE
Fix translation error for "Kikai wa mou shindeiru!" in sv.po

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -13320,7 +13320,7 @@ msgstr "Döda"
 
 #: src/gui/csPlayer.cpp:119
 msgid "Kikai wa mou shindeiru!"
-msgstr "Kone on jo kuollut!"
+msgstr "Maskinen är redan död!"
 
 #: src/gui/csPlayer.cpp:123
 msgid "Burn Current Song"


### PR DESCRIPTION
The translation that was updated was in Finnish, not Swedish. The error has now been corrected and fixed.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
