### PR TITLE
Add DS ROM export through my custom driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,6 +709,7 @@ src/engine/vgmOps.cpp
 src/engine/zsmOps.cpp
 src/engine/zsm.cpp
 src/engine/tiunaOps.cpp
+src/engine/ndsOps.cpp
 
 src/engine/platform/abstract.cpp
 src/engine/platform/genesis.cpp

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -705,6 +705,8 @@ class DivEngine {
     SafeWriter* saveZSM(unsigned int zsmrate=60, bool loop=true, bool optimize=true);
     // dump to TIunA.
     SafeWriter* saveTiuna(const bool* sysToExport, const char* baseLabel, int firstBankSize, int otherBankSize);
+    // dump to furDS.
+    SafeWriter* saveNDS(unsigned int refreshrate=60, bool loop=true);
     // dump command stream.
     SafeWriter* saveCommand();
     // export to text

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -104,7 +104,7 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
 
   //disCont[NDS].dispatch->renderSamples(NDS);
   size_t sampleMemLength = disCont[NDS].dispatch->getSampleMemUsage(NDS);
-  uint8_t *samples = (uint8_t *)disCont[NDS].dispatch->getSampleMem(NDS);
+  uint8_t *samples = (uint8_t*)disCont[NDS].dispatch->getSampleMem(NDS);
   offset = 0;
   w->writeText("unsigned char samples[] = {"); 
   for (size_t i = 0; i < sampleMemLength; i++) {

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -145,6 +145,7 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
         }
       }
     }
+    if (done) break;
     // get register dumps
     int i=0;
     if (NDS>=0) {

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -120,6 +120,9 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
     if (nextTick() || !playing) {
       done=true;
       if (!loop) {
+        writeByte(1);
+        writeByte(wait&0xff);
+        writeByte(wait>>8);
         for (int i=0; i<song.systemLen; i++) {
           disCont[i].dispatch->getRegisterWrites().clear();
         }

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -162,11 +162,18 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
       wait++;
       for (DivRegWrite& write: writes) {
         if (i==NDS) {
+/*
           if (write.addr==0x100&&write.addr<0x108) {
             //writeByte(2);
             //writeByte(write.addr&0xff);
             //writeByte(write.val&0xff);
           } else {
+            writeByte(0);
+            writeByte(write.addr&0xff);
+            writeByte(write.val&0xff);
+          }
+*/
+          if ((write.addr&0xff) == write.addr) {
             writeByte(0);
             writeByte(write.addr&0xff);
             writeByte(write.val&0xff);

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -1,0 +1,194 @@
+/**
+ * Furnace Tracker - multi-system chiptune tracker
+ * Copyright (C) 2021-2024 tildearrow and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "engine.h"
+#include "../ta-log.h"
+#include "../utfutils.h"
+#include "song.h"
+#include "platform/nds.h"
+
+SafeWriter* w;
+unsigned int offset = 0;
+
+static void writeByte(unsigned char byte) {
+  if ((offset&31) == 0) {
+    w->writeText("\n  "); 
+  }
+  w->writeText(fmt::format("0x{:02x}, ",byte)); 
+  offset++;
+}
+
+SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
+  int NDS=-1;
+  int IGNORED=0;
+
+  // find indexes for YM and VERA. Ignore other systems.
+  for (int i=0; i<song.systemLen; i++) {
+    switch (song.system[i]) {
+      case DIV_SYSTEM_NDS:
+        if (NDS>=0) {
+          IGNORED++;
+          break;
+        }
+        NDS=i;
+        logD("NDS detected as chip id %d",i);
+        break;
+      default:
+        IGNORED++;
+        logD("Ignoring chip %d systemID %d",i,(int)song.system[i]);
+        break;
+    }
+  }
+  if (NDS<0) {
+    logE("NDS not found");
+    return NULL;
+  }
+  if (IGNORED>0) {
+    logW("furDS export ignoring %d system%c",IGNORED,IGNORED>1?'s':' ');
+  }
+
+  stop();
+  repeatPattern=false;
+  setOrder(0);
+  BUSY_BEGIN_SOFT;
+
+  logI("exporting furDS C file at %d Hz",refreshrate);
+
+  double origRate=got.rate;
+  got.rate=(double)(refreshrate);
+
+  // determine loop point
+  int loopOrder=0;
+  int loopRow=0;
+  int loopEnd=0;
+  walkSong(loopOrder,loopRow,loopEnd);
+  logI("loop point: %d %d",loopOrder,loopRow);
+  warnings="";
+
+  w=new SafeWriter;
+  w->init();
+
+  // reset the playback state
+  curOrder=0;
+  freelance=false;
+  playing=false;
+  extValuePresent=false;
+  remainingLoops=-1;
+
+  // Prepare to write song data
+  playSub(false);
+  //size_t tickCount=0;
+  bool done=false;
+  bool loopNow=false;
+  int loopPos=-1;
+  int wait=0;
+  int oldWait=0;
+
+  if (NDS>=0) disCont[NDS].dispatch->toggleRegisterDump(true);
+
+  //disCont[NDS].dispatch->renderSamples(NDS);
+  size_t sampleMemLength = disCont[NDS].dispatch->getSampleMemUsage(NDS);
+  const void *samples = disCont[NDS].dispatch->getSampleMem(NDS);
+  offset = 0;
+  w->writeText("unsigned char samples[] = {"); 
+  for (size_t i = 0; i < sampleMemLength; i++) {
+    writeByte(*((uint8_t*)(samples+i)));
+  }
+  w->writeText("\n};\n");
+
+  w->writeText(fmt::format("\nunsigned int sampleLength = {};\n",sampleMemLength));
+
+  offset = 0;
+  w->writeText("unsigned char song[] = {"); 
+  while (!done) {
+    if (nextTick() || !playing) {
+      done=true;
+      if (!loop) {
+        for (int i=0; i<song.systemLen; i++) {
+          disCont[i].dispatch->getRegisterWrites().clear();
+        }
+        break;
+      }
+      if (!playing) {
+        loopPos=-1;
+      }
+    }
+    // get register dumps
+    int i=0;
+    if (NDS>=0) {
+      // dump NDS writes
+      i=NDS;
+      std::vector<DivRegWrite>& writes=disCont[i].dispatch->getRegisterWrites();
+      if (writes.size()>0) {
+        logD("ndsOps: Writing %d messages to chip %d",writes.size(),i);
+        writeByte(1);
+        writeByte(wait&0xff);
+        writeByte(wait>>8);
+        wait=0;
+      }
+      wait++;
+      for (DivRegWrite& write: writes) {
+        if (i==NDS) {
+          if (write.addr==0x100&&write.addr<0x108) {
+            //writeByte(2);
+            //writeByte(write.addr&0xff);
+            //writeByte(write.val&0xff);
+          } else {
+            writeByte(0);
+            writeByte(write.addr&0xff);
+            writeByte(write.val&0xff);
+          }
+        }
+      }
+      writes.clear();
+    }
+    if (loopPos==-1) {
+      if (loopOrder==curOrder && loopRow==curRow && loop)
+        loopNow=true;
+      if (loopNow) {
+        // If Virtual Tempo is in use, our exact loop point
+        // might be skipped due to quantization error.
+        // If this happens, the tick immediately following is our loop point.
+        if (ticks==1 || !(loopOrder==curOrder && loopRow==curRow)) {
+          loopPos=offset;
+          loopNow=false;
+        }
+      }
+    }
+  }
+  // end of song
+
+  // done - close out.
+  got.rate=origRate;
+  if (NDS>=0) disCont[NDS].dispatch->toggleRegisterDump(false);
+
+  remainingLoops=-1;
+  playing=false;
+  freelance=false;
+  extValuePresent=false;
+
+  w->writeText("\n};\n");
+
+  w->writeText(fmt::format("\nunsigned int songRate = {};\n",refreshrate));
+  w->writeText(fmt::format("\nint loopPoint = {};\n",loopPos));
+  w->writeText(fmt::format("\nunsigned int songLength = {};\n",offset));
+
+  BUSY_END;
+  return w;
+}

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -98,17 +98,17 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
   bool loopNow=false;
   int loopPos=-1;
   int wait=0;
-  int oldWait=0;
+  //int oldWait=0;
 
   if (NDS>=0) disCont[NDS].dispatch->toggleRegisterDump(true);
 
   //disCont[NDS].dispatch->renderSamples(NDS);
   size_t sampleMemLength = disCont[NDS].dispatch->getSampleMemUsage(NDS);
-  const void *samples = disCont[NDS].dispatch->getSampleMem(NDS);
+  uint8_t *samples = (uint8_t *)disCont[NDS].dispatch->getSampleMem(NDS);
   offset = 0;
   w->writeText("unsigned char samples[] = {"); 
   for (size_t i = 0; i < sampleMemLength; i++) {
-    writeByte(*((uint8_t*)(samples+i)));
+    writeByte(samples[i]);
   }
   w->writeText("\n};\n");
 

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -27,7 +27,7 @@ SafeWriter* w;
 unsigned int offset = 0;
 
 static void writeByte(unsigned char byte) {
-  if ((offset&31) == 0) {
+  if ((offset&31)==0) {
     w->writeText("\n  "); 
   }
   w->writeText(fmt::format("0x{:02x}, ",byte)); 
@@ -96,7 +96,7 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
 
   // Prepare to write song data
   playSub(false);
-  //size_t tickCount=0;
+  // size_t tickCount=0;
   bool done=false;
   bool loopNow=false;
   int loopPos=-1;
@@ -109,10 +109,10 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
 
   //disCont[NDS].dispatch->renderSamples(NDS);
   size_t sampleMemLength = disCont[NDS].dispatch->getSampleMemUsage(NDS);
-  uint8_t *samples = (uint8_t*)disCont[NDS].dispatch->getSampleMem(NDS);
+  unsigned char* samples = (unsigned char*)disCont[NDS].dispatch->getSampleMem(NDS);
   offset = 0;
   w->writeText("unsigned char samples[] = {"); 
-  for (size_t i = 0; i < sampleMemLength; i++) {
+  for (size_t i=0; i<sampleMemLength; i++) {
     writeByte(samples[i]);
   }
   w->writeText("\n};\n");
@@ -166,18 +166,7 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
       }
       for (DivRegWrite& write: writes) {
         if (i==NDS) {
-/*
-          if (write.addr==0x100&&write.addr<0x108) {
-            //writeByte(2);
-            //writeByte(write.addr&0xff);
-            //writeByte(write.val&0xff);
-          } else {
-            writeByte(0);
-            writeByte(write.addr&0xff);
-            writeByte(write.val&0xff);
-          }
-*/
-          if ((write.addr&0xff) == write.addr) {
+          if ((write.addr&0xff)==write.addr) {
             writeByte(0);
             writeByte(write.addr&0xff);
             writeByte(write.val&0xff);
@@ -191,7 +180,8 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
     fracWait+=cycles&MASTER_CLOCK_MASK;
     totalWait+=fracWait>>MASTER_CLOCK_PREC;
     fracWait&=MASTER_CLOCK_MASK;
-    if (totalWait>0 && !done) wait += totalWait;
+    if (totalWait>0 && !done)
+      wait+=totalWait;
   }
   // end of song
 

--- a/src/engine/ndsOps.cpp
+++ b/src/engine/ndsOps.cpp
@@ -132,6 +132,19 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
         loopPos=-1;
       }
     }
+    if (loopPos==-1) {
+      if (loopOrder==curOrder && loopRow==curRow && loop)
+        loopNow=true;
+      if (loopNow) {
+        // If Virtual Tempo is in use, our exact loop point
+        // might be skipped due to quantization error.
+        // If this happens, the tick immediately following is our loop point.
+        if (ticks==1 || !(loopOrder==curOrder && loopRow==curRow)) {
+          loopPos=offset;
+          loopNow=false;
+        }
+      }
+    }
     // get register dumps
     int i=0;
     if (NDS>=0) {
@@ -160,19 +173,6 @@ SafeWriter* DivEngine::saveNDS(unsigned int refreshrate, bool loop) {
         }
       }
       writes.clear();
-    }
-    if (loopPos==-1) {
-      if (loopOrder==curOrder && loopRow==curRow && loop)
-        loopNow=true;
-      if (loopNow) {
-        // If Virtual Tempo is in use, our exact loop point
-        // might be skipped due to quantization error.
-        // If this happens, the tick immediately following is our loop point.
-        if (ticks==1 || !(loopOrder==curOrder && loopRow==curRow)) {
-          loopPos=offset;
-          loopNow=false;
-        }
-      }
     }
   }
   // end of song

--- a/src/gui/exportOptions.cpp
+++ b/src/gui/exportOptions.cpp
@@ -504,6 +504,9 @@ void FurnaceGUI::drawExport() {
     case GUI_EXPORT_TIUNA:
       drawExportTiuna(true);
       break;
+    case GUI_EXPORT_NDS:
+      drawExportNDS(true);
+      break;
     case GUI_EXPORT_AMIGA_VAL:
       drawExportAmigaVal(true);
       break;

--- a/src/gui/exportOptions.cpp
+++ b/src/gui/exportOptions.cpp
@@ -299,6 +299,27 @@ void FurnaceGUI::drawExportTiuna(bool onWindow) {
   }
 }
 
+void FurnaceGUI::drawExportNDS(bool onWindow) {
+  exitDisabledTimer=1;
+
+  ImGui::Text(_("for use with the furDS driver. outputs C source."));
+  if (ImGui::InputInt(_("Tick Rate (Hz)"),&ndsExportTickRate,1,2)) {
+    if (ndsExportTickRate<1) ndsExportTickRate=1;
+    if (ndsExportTickRate>44100) ndsExportTickRate=44100;
+  }
+  ImGui::Checkbox(_("loop"),&ndsExportLoop);
+  if (onWindow) {
+    ImGui::Separator();
+    if (ImGui::Button(_("Cancel"),ImVec2(200.0f*dpiScale,0))) ImGui::CloseCurrentPopup();
+    ImGui::SameLine();
+  }
+  if (ImGui::Button(_("Export"),ImVec2(200.0f*dpiScale,0))) {
+    openFileDialog(GUI_FILE_EXPORT_NDS);
+    ImGui::CloseCurrentPopup();
+  }
+}
+
+
 void FurnaceGUI::drawExportAmigaVal(bool onWindow) {
   exitDisabledTimer=1;
 
@@ -435,6 +456,17 @@ void FurnaceGUI::drawExport() {
           ImGui::EndTabItem();
         }
       }
+      int numNDSCompat=0;
+      for (int i=0; i<e->song.systemLen; i++) {
+        if (e->song.system[i]==DIV_SYSTEM_NDS) numNDSCompat++;
+      }
+      if (numNDSCompat) {
+        if (ImGui::BeginTabItem(_("furDS"))) {
+          drawExportNDS(true);
+          ImGui::EndTabItem();
+        }
+      }
+
       int numAmiga=0;
       for (int i=0; i<e->song.systemLen; i++) {
         if (e->song.system[i]==DIV_SYSTEM_AMIGA) numAmiga++;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -4283,6 +4283,19 @@ bool FurnaceGUI::loop() {
               ImGui::EndMenu();
             }
           }
+          bool hasTiunaCompat=false;
+          for (int i=0; i<e->song.systemLen; i++) {
+            if (e->song.system[i]==DIV_SYSTEM_TIA) {
+              hasTiunaCompat=true;
+              break;
+            }
+          }
+          if (hasTiunaCompat) {
+            if (ImGui::BeginMenu(_("export TIunA..."))) {
+              drawExportTiuna();
+              ImGui::EndMenu();
+            }
+          }
           int numNDSCompat=0;
           for (int i=0; i<e->song.systemLen; i++) {
             if (e->song.system[i]==DIV_SYSTEM_NDS) numNDSCompat++;
@@ -4332,6 +4345,19 @@ bool FurnaceGUI::loop() {
             if (ImGui::MenuItem(_("export ZSM..."))) {
               curExportType=GUI_EXPORT_ZSM;
               displayExport=true;
+            }
+          }
+          bool hasTiunaCompat=false;
+          for (int i=0; i<e->song.systemLen; i++) {
+            if (e->song.system[i]==DIV_SYSTEM_TIA) {
+              hasTiunaCompat=true;
+              break;
+            }
+          }
+          if (hasTiunaCompat) {
+            if (ImGui::BeginMenu(_("export TIunA..."))) {
+              drawExportTiuna();
+              ImGui::EndMenu();
             }
           }
           int numNDSCompat=0;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -4355,9 +4355,9 @@ bool FurnaceGUI::loop() {
             }
           }
           if (hasTiunaCompat) {
-            if (ImGui::BeginMenu(_("export TIunA..."))) {
-              drawExportTiuna();
-              ImGui::EndMenu();
+            if (ImGui::MenuItem(_("export TIunA..."))) {
+              curExportType=GUI_EXPORT_TIUNA;
+              displayExport=true;
             }
           }
           int numNDSCompat=0;
@@ -4365,7 +4365,7 @@ bool FurnaceGUI::loop() {
             if (e->song.system[i]==DIV_SYSTEM_NDS) numNDSCompat++;
           }
           if (numNDSCompat>0) {
-            if (ImGui::BeginMenu(_("export furDS music data..."))) {
+            if (ImGui::MenuItem(_("export furDS music data..."))) {
               curExportType=GUI_EXPORT_NDS;
               displayExport=true;
             }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -591,6 +591,7 @@ enum FurnaceGUIFileDialogs {
   GUI_FILE_EXPORT_AUDIO_PER_CHANNEL,
   GUI_FILE_EXPORT_VGM,
   GUI_FILE_EXPORT_ZSM,
+  GUI_FILE_EXPORT_NDS,
   GUI_FILE_EXPORT_TIUNA,
   GUI_FILE_EXPORT_CMDSTREAM,
   GUI_FILE_EXPORT_TEXT,
@@ -644,6 +645,7 @@ enum FurnaceGUIExportTypes {
   GUI_EXPORT_AUDIO=0,
   GUI_EXPORT_VGM,
   GUI_EXPORT_ZSM,
+  GUI_EXPORT_NDS,
   GUI_EXPORT_TIUNA,
   GUI_EXPORT_CMD_STREAM,
   GUI_EXPORT_AMIGA_VAL,
@@ -1601,7 +1603,7 @@ class FurnaceGUI {
   std::vector<String> availRenderDrivers;
   std::vector<String> availAudioDrivers;
 
-  bool quit, warnQuit, willCommit, edit, editClone, isPatUnique, modified, displayError, displayExporting, vgmExportLoop, zsmExportLoop, zsmExportOptimize, vgmExportPatternHints;
+  bool quit, warnQuit, willCommit, edit, editClone, isPatUnique, modified, displayError, displayExporting, vgmExportLoop, zsmExportLoop, ndsExportLoop, zsmExportOptimize, vgmExportPatternHints;
   bool vgmExportDirectStream, displayInsTypeList, displayWaveSizeList;
   bool portrait, injectBackUp, mobileMenuOpen, warnColorPushed;
   bool wantCaptureKeyboard, oldWantCaptureKeyboard, displayMacroMenu;
@@ -1621,6 +1623,7 @@ class FurnaceGUI {
   int cvHiScore;
   int drawHalt;
   int zsmExportTickRate;
+  int ndsExportTickRate;
   String asmBaseLabel;
   int tiunaFirstBankSize;
   int tiunaOtherBankSize;
@@ -2675,6 +2678,7 @@ class FurnaceGUI {
   void drawExportAudio(bool onWindow=false);
   void drawExportVGM(bool onWindow=false);
   void drawExportZSM(bool onWindow=false);
+  void drawExportNDS(bool onWindow=false);
   void drawExportTiuna(bool onWindow=false);
   void drawExportAmigaVal(bool onWindow=false);
   void drawExportText(bool onWindow=false);


### PR DESCRIPTION
<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
tl;dr: I made a custom export function and driver for DS ROM Export

Hello! I sometimes like to do DS homebrew for fun and I've done a few things for it (but most of them are unpublished though). 
However, there aren't many options for audio playback on the DS outside of what libnds and Maxmod provides, and I wanted to do/use something different which actually supports things like the DS' PSG without much hassle. So I added Furnace ROM export for the DS!

This PR adds ROM export support for the DS through a basic register dump format in a C array for easy use with my custom driver called **furDS**. furDS uses the C source code dump that's generated/exported by Furnace for both sample and music data. 

The driver is mostly contained on the ARM9 CPU of the DS, and since you can only access the sound-chip through the ARM7 core I had to use a FIFO buffer for writing registers 32-bits at a time through the other CPU. 
Because of this, I had to implement some fail-safe code for when the FIFO buffer overflows/overruns, so when there's too many things going on in a tune there may be some dropped notes.

When the export function gets added you can export by going to `file -> export... -> furDS` and exporting the file to `furDS_directory/arm9/source/music.c` **where the `furDS_directory` folder is a git clone of my [driver template repository](https://github.com/AnnoyedArt1256/furDS)**.

<details>
<summary>WARNING: A short tangent about why I chose register dumps</summary>
By the way, I do know that register dumps are normally frowned upon, but the DS has a lot of RAM so it does suffice for now. I mean Furnace has a very complicated player and even with a command stream-based driver, things like macros wouldn't have full compatability.
</details>