### PR TITLE
Instrument editor undo

### DIFF
--- a/src/engine/instrument.cpp
+++ b/src/engine/instrument.cpp
@@ -460,7 +460,7 @@ void DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrum
     step.clear(); // don't let it delete the data ptr that's been copied!
     undoHist.push_back(stepPtr);
 
-    logI("DivInstrument::undoHist push (%u off, %u size)", stepPtr->podPatch.offset, stepPtr->podPatch.size);
+    // logI("DivInstrument::undoHist push (%u off, %u size)", stepPtr->podPatch.offset, stepPtr->podPatch.size);
   }
 }
 
@@ -469,7 +469,7 @@ int DivInstrument::undo() {
 
   DivInstrumentUndoStep* step=undoHist.back();
   undoHist.pop_back();
-  logI("DivInstrument::undo (%u off, %u size)", step->podPatch.offset, step->podPatch.size);
+  // logI("DivInstrument::undo (%u off, %u size)", step->podPatch.offset, step->podPatch.size);
   step->applyAndReverse(this);
 
   // make room
@@ -488,7 +488,7 @@ int DivInstrument::redo() {
 
   DivInstrumentUndoStep* step = redoHist.back();
   redoHist.pop_back();
-  logI("DivInstrument::redo (%u off, %u size)", step->podPatch.offset, step->podPatch.size);
+  // logI("DivInstrument::redo (%u off, %u size)", step->podPatch.offset, step->podPatch.size);
   step->applyAndReverse(this);
 
   // make room

--- a/src/engine/instrument.cpp
+++ b/src/engine/instrument.cpp
@@ -428,7 +428,7 @@ bool DivInstrumentUndoStep::makeUndoPatch(size_t processTime_, const DivInstrume
 
   // create the patch that will make post into pre
   podPatch.calcDiff((const DivInstrumentPOD*)post, (const DivInstrumentPOD*)pre, sizeof(DivInstrumentPOD));
-  if (pre->name!=post->name != 0) {
+  if (pre->name!=post->name) {
     nameValid=true;
     name=pre->name;
   }

--- a/src/engine/instrument.cpp
+++ b/src/engine/instrument.cpp
@@ -376,6 +376,8 @@ bool MemPatch::calcDiff(const void* pre, const void* post, size_t inputSize) {
   const unsigned char* preBytes=(const unsigned char*)pre;
   const unsigned char* postBytes=(const unsigned char*)post;
 
+  // @NOTE: consider/profile using a memcmp==0 check to early-out, if it's potentially faster
+  // for the common case, which is no change
   for (size_t ii=0; ii<inputSize; ++ii) {
     if (preBytes[ii] != postBytes[ii]) {
       lastDiff=ii;
@@ -439,7 +441,7 @@ bool DivInstrumentUndoStep::makeUndoPatch(size_t processTime_, const DivInstrume
   return nameValid || podPatch.isValid();
 }
 
-void DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrument* old) {
+bool DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrument* old) {
   DivInstrumentUndoStep step;
 
   // generate a patch to go back to old
@@ -464,7 +466,10 @@ void DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrum
     undoHist.push_back(stepPtr);
 
     // logI("DivInstrument::undoHist push (%u off, %u size)", stepPtr->podPatch.offset, stepPtr->podPatch.size);
+    return true;
   }
+
+  return false;
 }
 
 int DivInstrument::undo() {

--- a/src/engine/instrument.cpp
+++ b/src/engine/instrument.cpp
@@ -365,19 +365,19 @@ void DivInstrument::writeFeatureFM(SafeWriter* w, bool fui) {
 }
 
 void MemPatch::clear() {
-  data = nullptr;
-  offset = 0;
-  size = 0;
+  data = NULL;
+  offset=0;
+  size=0;
 }
 
 bool MemPatch::calcDiff(const void* pre, const void* post, size_t inputSize) {
-  bool diffValid = false;
-  size_t firstDiff = 0;
-  size_t lastDiff = 0;
-  const uint8_t* preBytes = (const uint8_t*)pre;
-  const uint8_t* postBytes = (const uint8_t*)post;
+  bool diffValid=false;
+  size_t firstDiff=0;
+  size_t lastDiff=0;
+  const unsigned char* preBytes=(const unsigned char*)pre;
+  const unsigned char* postBytes=(const unsigned char*)post;
 
-  for (size_t ii = 0; ii < inputSize; ++ii) {
+  for (size_t ii=0; ii<inputSize; ++ii) {
     if (preBytes[ii] != postBytes[ii]) {
       lastDiff=ii;
       firstDiff=diffValid ? firstDiff : ii;
@@ -386,27 +386,27 @@ bool MemPatch::calcDiff(const void* pre, const void* post, size_t inputSize) {
   }
 
   if (diffValid) {
-    offset = firstDiff;
-    size = lastDiff - firstDiff + 1;
-    data = new uint8_t[size];
+    offset=firstDiff;
+    size=lastDiff - firstDiff + 1;
+    data=new unsigned char[size];
 
     // the diff is to make pre into post (MemPatch is general, not specific to
     // undo), so copy from postBytes
-    memcpy(data, postBytes + offset, size);
+    memcpy(data, postBytes+offset, size);
   }
 
   return diffValid;
 }
 
 void MemPatch::applyAndReverse(void* target, size_t targetSize) {
-  if (size == 0) { return; }
-  assert(offset + size <= targetSize);
-  uint8_t* targetBytes = (uint8_t*)target;
+  if (size==0) return;
+  assert(offset+size<=targetSize);
+  unsigned char* targetBytes=(unsigned char*)target;
 
   // swap this->data and its segment on target
-  for (size_t ii = 0; ii < size; ++ii) {
-    uint8_t tmp = targetBytes[offset + ii];
-    targetBytes[offset + ii] = data[ii];
+  for (size_t ii=0; ii<size; ++ii) {
+    unsigned char tmp=targetBytes[offset+ii];
+    targetBytes[offset+ii] = data[ii];
     data[ii] = tmp;
   }
 }
@@ -424,13 +424,13 @@ void DivInstrumentUndoStep::applyAndReverse(DivInstrument* target) {
 }
 
 bool DivInstrumentUndoStep::makeUndoPatch(size_t processTime_, const DivInstrument* pre, const DivInstrument* post) {
-  processTime = processTime_;
+  processTime=processTime_;
 
   // create the patch that will make post into pre
   podPatch.calcDiff((const DivInstrumentPOD*)post, (const DivInstrumentPOD*)pre, sizeof(DivInstrumentPOD));
-  if (pre->name.compare(post->name) != 0) {
-    nameValid = true;
-    name = pre->name;
+  if (pre->name!=post->name != 0) {
+    nameValid=true;
+    name=pre->name;
   }
 
   return nameValid || podPatch.isValid();
@@ -443,7 +443,7 @@ void DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrum
   if (step.makeUndoPatch(processTime, old, this)) {
     
       // make room
-    if (undoHist.size() >= undoHist.capacity()) {
+    if (undoHist.size()>=undoHist.capacity()) {
       DivInstrumentUndoStep* step = undoHist.front();
       delete step;
       undoHist.pop_front();
@@ -455,8 +455,8 @@ void DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrum
       redoHist.pop_back();
     }
 
-    DivInstrumentUndoStep* stepPtr = new DivInstrumentUndoStep;
-    *stepPtr = step;
+    DivInstrumentUndoStep* stepPtr=new DivInstrumentUndoStep;
+    *stepPtr=step;
     step.clear(); // don't let it delete the data ptr that's been copied!
     undoHist.push_back(stepPtr);
 
@@ -465,16 +465,16 @@ void DivInstrument::recordUndoStepIfChanged(size_t processTime, const DivInstrum
 }
 
 int DivInstrument::undo() {
-  if (undoHist.empty()) { return 0; }
+  if (undoHist.empty()) return 0;
 
-  DivInstrumentUndoStep* step = undoHist.back();
+  DivInstrumentUndoStep* step=undoHist.back();
   undoHist.pop_back();
   logI("DivInstrument::undo (%u off, %u size)", step->podPatch.offset, step->podPatch.size);
   step->applyAndReverse(this);
 
   // make room
-  if (redoHist.size() >= redoHist.capacity()) {
-      DivInstrumentUndoStep* step = redoHist.front();
+  if (redoHist.size()>=redoHist.capacity()) {
+      DivInstrumentUndoStep* step=redoHist.front();
       delete step;
       redoHist.pop_front();
   }
@@ -484,7 +484,7 @@ int DivInstrument::undo() {
 }
 
 int DivInstrument::redo() {
-  if (redoHist.empty()) { return 0; }
+  if (redoHist.empty()) return 0;
 
   DivInstrumentUndoStep* step = redoHist.back();
   redoHist.pop_back();
@@ -492,8 +492,8 @@ int DivInstrument::redo() {
   step->applyAndReverse(this);
 
   // make room
-  if (undoHist.size() >= undoHist.capacity()) {
-      DivInstrumentUndoStep* step = undoHist.front();
+  if (undoHist.size()>=undoHist.capacity()) {
+      DivInstrumentUndoStep* step=undoHist.front();
       delete step;
       undoHist.pop_front();
   }

--- a/src/engine/instrument.cpp
+++ b/src/engine/instrument.cpp
@@ -17,7 +17,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <cassert>
 #include "dataErrors.h"
 #include "engine.h"
 #include "instrument.h"
@@ -400,7 +399,11 @@ bool MemPatch::calcDiff(const void* pre, const void* post, size_t inputSize) {
 
 void MemPatch::applyAndReverse(void* target, size_t targetSize) {
   if (size==0) return;
-  assert(offset+size<=targetSize);
+  if (offset+size>targetSize) {
+    logW("MemPatch (offset %d, size %d) exceeds target size (%d), can't apply!",offset,size,targetSize);
+    return;
+  }
+
   unsigned char* targetBytes=(unsigned char*)target;
 
   // swap this->data and its segment on target

--- a/src/engine/instrument.h
+++ b/src/engine/instrument.h
@@ -888,7 +888,7 @@ struct DivInstrumentPOD {
 
 struct MemPatch {
   MemPatch() :
-    data(nullptr)
+    data(NULL)
     , offset(0)
     , size(0) {
   }
@@ -902,9 +902,9 @@ struct MemPatch {
   void clear();
   bool calcDiff(const void* pre, const void* post, size_t size);
   void applyAndReverse(void* target, size_t inputSize);
-  bool isValid() const { return size > 0; }
+  bool isValid() const { return size>0; }
 
-  uint8_t* data;
+  unsigned char* data;
   size_t offset;
   size_t size;
 };

--- a/src/engine/instrument.h
+++ b/src/engine/instrument.h
@@ -934,7 +934,7 @@ struct DivInstrument : DivInstrumentPOD {
    */
   FixedQueue<DivInstrumentUndoStep*, 128> undoHist;
   FixedQueue<DivInstrumentUndoStep*, 128> redoHist;
-  void recordUndoStepIfChanged(size_t processTime, const DivInstrument* old);
+  bool recordUndoStepIfChanged(size_t processTime, const DivInstrument* old);
   int undo();
   int redo();
 

--- a/src/engine/instrument.h
+++ b/src/engine/instrument.h
@@ -1025,7 +1025,7 @@ struct DivInstrument : DivInstrumentPOD {
   DivInstrument() :
     name("") {
       // clear and construct DivInstrumentPOD so it doesn't have any garbage in the padding
-      memset((DivInstrumentPOD*)this, 0, sizeof(DivInstrumentPOD));
+      memset((unsigned char*)this, 0, sizeof(DivInstrumentPOD));
       new ((DivInstrumentPOD*)this) DivInstrumentPOD;
   }
 };

--- a/src/fixedQueue.h
+++ b/src/fixedQueue.h
@@ -24,7 +24,7 @@
 #include "ta-log.h"
 
 template<typename T, size_t items> struct FixedQueue {
-  size_t readPos, writePos;
+  size_t readPos, curSize;
   T data[items];
 
   T& operator[](size_t pos);
@@ -41,17 +41,21 @@ template<typename T, size_t items> struct FixedQueue {
   bool push_back(const T& item);
   void clear();
   bool empty();
+  size_t writePos();
   size_t size();
+  size_t capacity();
   FixedQueue():
     readPos(0),
-    writePos(0) {}
+    curSize(0) {}
 };
 
 template <typename T, size_t items> T& FixedQueue<T,items>::operator[](size_t pos) {
-  if (pos>=size()) {
+  if (pos>=curSize) {
     logW("accessing invalid position. bug!");
   }
-  return data[(readPos+pos)%items];
+  size_t idx=readPos+pos;
+  if (idx>=items) idx-=items;
+  return data[idx];
 }
 
 template <typename T, size_t items> T& FixedQueue<T,items>::front() {
@@ -59,12 +63,13 @@ template <typename T, size_t items> T& FixedQueue<T,items>::front() {
 }
 
 template <typename T, size_t items> T& FixedQueue<T,items>::back() {
-  if (writePos==0) return data[items-1];
-  return data[writePos-1];
+  if (curSize==0) return data[0];
+  size_t idx=readPos+curSize-1;
+  if (idx>=items) idx-=items;
+  return data[idx];
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::erase(size_t pos) {
-  size_t curSize=size();
   if (pos>=curSize) {
     logW("accessing invalid position. bug!");
     return false;
@@ -84,72 +89,56 @@ template <typename T, size_t items> bool FixedQueue<T,items>::erase(size_t pos) 
     p1++;
   }
 
-  if (writePos>0) {
-    writePos--;
-  } else {
-    writePos=items-1;
-  }
-  
+  curSize--;  
   return true;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::pop() {
-  if (readPos==writePos) return false;
-  if (++readPos>=items) readPos=0;
+  if (curSize==0) return false;
+  curSize--;
   return true;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::push(const T& item) {
-  if (writePos==(readPos-1)) {
+  if (curSize==items) {
     //logW("queue overflow!");
     return false;
   }
-  if (writePos==items-1 && readPos==0) {
-    //logW("queue overflow!");
-    return false;
-  }
-  data[writePos]=item;
-  if (++writePos>=items) writePos=0;
+  size_t idx=readPos+curSize;
+  if (idx>=items) { idx-=items; }
+  data[idx]=item;
+  curSize++;
   return true;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::pop_front() {
-  if (readPos==writePos) return false;
+  if (curSize==0) return false;
   if (++readPos>=items) readPos=0;
+  curSize--;
   return true;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::push_back(const T& item) {
-  if (writePos==(readPos-1)) {
+  if (curSize==items) {
     //logW("queue overflow!");
     return false;
   }
-  if (writePos==items-1 && readPos==0) {
-    //logW("queue overflow!");
-    return false;
-  }
-  data[writePos]=item;
-  if (++writePos>=items) writePos=0;
+  size_t idx=readPos+curSize;
+  if (idx>=items) { idx-=items; }
+  data[idx]=item;
+  curSize++;
   return true;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::pop_back() {
-  if (readPos==writePos) return false;
-  if (writePos>0) {
-    writePos--;
-  } else {
-    writePos=items-1;
-  }
+  if (curSize==0) return false;
+  curSize--;
   return true;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::push_front(const T& item) {
-  if (readPos==(writePos+1)) {
-    //logW("stack overflow!");
-    return false;
-  }
-  if (readPos==0 && writePos==items-1) {
-    //logW("stack overflow!");
+  if (curSize==items) {
+    //logW("queue overflow!");
     return false;
   }
   if (readPos>0) {
@@ -158,23 +147,31 @@ template <typename T, size_t items> bool FixedQueue<T,items>::push_front(const T
     readPos=items-1;
   }
   data[readPos]=item;
+  curSize++;
   return true;
 }
 
 template <typename T, size_t items> void FixedQueue<T,items>::clear() {
   readPos=0;
-  writePos=0;
+  curSize=0;
 }
 
 template <typename T, size_t items> bool FixedQueue<T,items>::empty() {
-  return (readPos==writePos);
+  return curSize==0;
+}
+
+template <typename T, size_t items> size_t FixedQueue<T,items>::writePos() {
+  size_t idx=readPos+curSize;
+  if (idx>=items) { idx-=items; }
+  return idx;
 }
 
 template <typename T, size_t items> size_t FixedQueue<T,items>::size() {
-  if (readPos>writePos) {
-    return items+writePos-readPos;
-  }
-  return writePos-readPos;
+  return curSize;
+}
+
+template <typename T, size_t items> size_t FixedQueue<T,items>::capacity() {
+  return items;
 }
 
 #endif

--- a/src/gui/debugWindow.cpp
+++ b/src/gui/debugWindow.cpp
@@ -603,7 +603,7 @@ void FurnaceGUI::drawDebug() {
     }
     if (ImGui::TreeNode("Recent Files")) {
       ImGui::Text("Items: %d - Max: %d",(int)recentFile.size(),settings.maxRecentFile);
-      ImGui::Text("readPos: %d - writePos: %d",(int)recentFile.readPos,(int)recentFile.writePos);
+      ImGui::Text("readPos: %d - writePos: %d",(int)recentFile.readPos,(int)recentFile.writePos());
       ImGui::Indent();
       for (size_t i=0; i<recentFile.size(); i++) {
         ImGui::Text("%d: %s",(int)i,recentFile[i].c_str());

--- a/src/gui/doAction.cpp
+++ b/src/gui/doAction.cpp
@@ -73,6 +73,8 @@ void FurnaceGUI::doAction(int what) {
     case GUI_ACTION_UNDO:
       if (curWindow==GUI_WINDOW_SAMPLE_EDIT) {
         doUndoSample();
+      } else if (curWindow==GUI_WINDOW_INS_EDIT) {
+        doUndoInstrument();
       } else {
         doUndo();
       }
@@ -80,6 +82,8 @@ void FurnaceGUI::doAction(int what) {
     case GUI_ACTION_REDO:
       if (curWindow==GUI_WINDOW_SAMPLE_EDIT) {
         doRedoSample();
+      } else if (curWindow==GUI_WINDOW_INS_EDIT) {
+        doRedoInstrument();
       } else {
         doRedo();
       }

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -7952,6 +7952,7 @@ FurnaceGUI::FurnaceGUI():
   localeRequiresChineseTrad(false),
   localeRequiresKorean(false),
   prevInsData(NULL),
+  cachedCurInsPtr(NULL),
   pendingLayoutImport(NULL),
   pendingLayoutImportLen(0),
   pendingLayoutImportStep(0),

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2258,6 +2258,8 @@ class FurnaceGUI {
   std::vector<ImWchar> localeExtraRanges;
 
   DivInstrument* prevInsData;
+  DivInstrument cachedCurIns;
+  DivInstrument* cachedCurInsPtr;
 
   unsigned char* pendingLayoutImport;
   size_t pendingLayoutImportLen;
@@ -2912,6 +2914,9 @@ class FurnaceGUI {
 
   void doUndoSample();
   void doRedoSample();
+
+  void doUndoInstrument();
+  void doRedoInstrument();
 
   void play(int row=0);
   void setOrder(unsigned char order, bool forced=false);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2260,6 +2260,7 @@ class FurnaceGUI {
   DivInstrument* prevInsData;
   DivInstrument cachedCurIns;
   DivInstrument* cachedCurInsPtr;
+  bool insEditMayBeDirty;
 
   unsigned char* pendingLayoutImport;
   size_t pendingLayoutImportLen;
@@ -2915,6 +2916,7 @@ class FurnaceGUI {
   void doUndoSample();
   void doRedoSample();
 
+  void checkRecordInstrumentUndoStep();
   void doUndoInstrument();
   void doRedoInstrument();
 

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -7743,7 +7743,7 @@ void FurnaceGUI::drawInsEdit() {
 }
 
 void FurnaceGUI::checkRecordInstrumentUndoStep() {
-  if (curIns>=0 && curIns<(int)e->song.ins.size()) {
+  if (insEditOpen && curIns>=0 && curIns<(int)e->song.ins.size()) {
     DivInstrument* ins=e->song.ins[curIns];
 
     // invalidate cachedCurIns/any possible changes if the cachedCurIns was referencing a different

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -5250,7 +5250,7 @@ void FurnaceGUI::drawInsEdit() {
     ImGui::SetNextWindowSizeConstraints(ImVec2(440.0f*dpiScale,400.0f*dpiScale),ImVec2(canvasW,canvasH));
   }
   if (ImGui::Begin("Instrument Editor",&insEditOpen,globalWinFlags|(settings.allowEditDocking?0:ImGuiWindowFlags_NoDocking),_("Instrument Editor"))) {
-    DivInstrument* ins=nullptr;
+    DivInstrument* ins=NULL;
     if (curIns==-2) {
       ImGui::SetCursorPosY(ImGui::GetCursorPosY()+(ImGui::GetContentRegionAvail().y-ImGui::GetFrameHeightWithSpacing()+ImGui::GetStyle().ItemSpacing.y)*0.5f);
       CENTER_TEXT(_("waiting..."));
@@ -7738,8 +7738,8 @@ void FurnaceGUI::drawInsEdit() {
     }
     
     if (ins) {
-      bool insChanged = ins != cachedCurInsPtr;
-      bool delayDiff = ImGui::IsMouseDown(ImGuiMouseButton_Left) || ImGui::IsMouseDown(ImGuiMouseButton_Right) || ImGui::GetIO().WantCaptureKeyboard;
+      bool insChanged=ins!=cachedCurInsPtr;
+      bool delayDiff=ImGui::IsMouseDown(ImGuiMouseButton_Left) || ImGui::IsMouseDown(ImGuiMouseButton_Right) || ImGui::GetIO().WantCaptureKeyboard;
 
       // check against the last cached to see if diff -- note that modifications to instruments happen outside
       // drawInsEdit (e.g. cursor inputs are processed and can directly modify macro data)
@@ -7748,12 +7748,12 @@ void FurnaceGUI::drawInsEdit() {
       }
 
       if (insChanged || !delayDiff) {
-        cachedCurIns = *ins;
+        cachedCurIns=*ins;
       }
 
-      cachedCurInsPtr = ins;
+      cachedCurInsPtr=ins;
     } else {
-      cachedCurInsPtr = nullptr;
+      cachedCurInsPtr=NULL;
     }
   }
   

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -5250,6 +5250,7 @@ void FurnaceGUI::drawInsEdit() {
     ImGui::SetNextWindowSizeConstraints(ImVec2(440.0f*dpiScale,400.0f*dpiScale),ImVec2(canvasW,canvasH));
   }
   if (ImGui::Begin("Instrument Editor",&insEditOpen,globalWinFlags|(settings.allowEditDocking?0:ImGuiWindowFlags_NoDocking),_("Instrument Editor"))) {
+    DivInstrument* ins=nullptr;
     if (curIns==-2) {
       ImGui::SetCursorPosY(ImGui::GetCursorPosY()+(ImGui::GetContentRegionAvail().y-ImGui::GetFrameHeightWithSpacing()+ImGui::GetStyle().ItemSpacing.y)*0.5f);
       CENTER_TEXT(_("waiting..."));
@@ -5277,6 +5278,7 @@ void FurnaceGUI::drawInsEdit() {
                 curIns=i;
                 wavePreviewInit=true;
                 updateFMPreview=true;
+                ins = e->song.ins[curIns];
               }
             }
             ImGui::EndCombo();
@@ -5299,7 +5301,7 @@ void FurnaceGUI::drawInsEdit() {
         ImGui::EndTable();
       }
     } else {
-      DivInstrument* ins=e->song.ins[curIns];
+      ins=e->song.ins[curIns];
       if (updateFMPreview) {
         renderFMPreview(ins);
         updateFMPreview=false;
@@ -7734,7 +7736,51 @@ void FurnaceGUI::drawInsEdit() {
       
       ImGui::EndPopup();
     }
+    
+    if (ins) {
+      bool insChanged = ins != cachedCurInsPtr;
+      bool delayDiff = ImGui::IsMouseDown(ImGuiMouseButton_Left) || ImGui::IsMouseDown(ImGuiMouseButton_Right) || ImGui::GetIO().WantCaptureKeyboard;
+
+      // check against the last cached to see if diff -- note that modifications to instruments happen outside
+      // drawInsEdit (e.g. cursor inputs are processed and can directly modify macro data)
+      if (!insChanged && !delayDiff) {
+        ins->recordUndoStepIfChanged(e->processTime, &cachedCurIns);
+      }
+
+      if (insChanged || !delayDiff) {
+        cachedCurIns = *ins;
+      }
+
+      cachedCurInsPtr = ins;
+    } else {
+      cachedCurInsPtr = nullptr;
+    }
   }
+  
   if (ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows)) curWindow=GUI_WINDOW_INS_EDIT;
   ImGui::End();
+}
+
+void FurnaceGUI::doUndoInstrument() {
+  if (!insEditOpen) return;
+  if (curIns<0 || curIns>=(int)e->song.ins.size()) return;
+  DivInstrument* ins=e->song.ins[curIns];
+  // is locking the engine necessary? copied from doUndoSample
+  e->lockEngine([this,ins]() {
+    ins->undo();
+    cachedCurInsPtr=ins;
+    cachedCurIns=*ins;
+  });
+}
+
+void FurnaceGUI::doRedoInstrument() {
+  if (!insEditOpen) return;
+  if (curIns<0 || curIns>=(int)e->song.ins.size()) return;
+  DivInstrument* ins=e->song.ins[curIns];
+  // is locking the engine necessary? copied from doRedoSample
+  e->lockEngine([this,ins]() {
+    ins->redo();
+    cachedCurInsPtr=ins;
+    cachedCurIns=*ins;
+  });
 }


### PR DESCRIPTION
Based roughly on the sample editor's undo feature --

- separate undo/redo stacks per DivInstrument
- DivInstrument refactored to inherit from an underlying plain-old-data DivInstrumentPOD (`String name` was the only non-POD member)
- undo stack consists of "diffs/patches", which consist of a `MemPatch` (direct memory diff, only as large as the actual changed region of memory) and a `String name` (for name changes)
- DivInstrument clears DivInstrumentPOD to zero and then reruns the constructor, ensuring no garbage in uninitialized areas/padding (necessary because we're generating diffs directly from memory)
- diffs are generated by caching a copy of the current DivInstrument in FurnaceGUI and comparing the latest current DivInstrument to the older copy.  this happens at the end of drawInsEdit
- (notably, DivInstrument can be modified outside drawInsEdit, e.g. via processDrags/pointMotion, otherwise we could just cache the DivInstrument copy on the stack at the start of drawInsEdit)
- to avoid generating diffs for every single change to memory (which would be hundreds when e.g. drawing macros, dragging sliders, keystrokes, etc.), we delay generating a diff as long as the mouse left/right are down or a text field is open

Potential future issues/work
- the current approach to avoiding generating loads of diffs wouldn't work if we support other input methods like mousewheel or MIDI learn.  my thought was to use elapsed process time and adjacency/overlap of memory patches
- haven't looked at memory usage
- haven't tested a whole lot... concerned slightly about DivInstrument fields that reference outside resources like samples (or sample indices?)
- haven't profiled my FixedQueue fix, you said that modulus would be a problem so i just used the same more limited `if (idx>=cap) idx-=cap;` and figured it was ok, i'm no low-level pro by any means!