### PR TITLE
GB: enable VIN input to accomodate multiple chips on hardware

### DIFF
--- a/src/engine/platform/gb.cpp
+++ b/src/engine/platform/gb.cpp
@@ -651,7 +651,7 @@ void DivPlatformGB::reset() {
   immWrite(0x26,0x8f);
   lastPan=0xff;
   immWrite(0x25,procMute());
-  immWrite(0x24,0x77);
+  immWrite(0x24,0xff);
 
   antiClickPeriodCount=0;
   antiClickWavePos=0;


### PR DESCRIPTION
This will allow exported VGMs that have GB + another chip to work on hardware, provided the extra chip is available via VIN.