### PR TITLE
S3M import improvements

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -597,7 +597,7 @@ class DivEngine {
   bool loadDMF(unsigned char* file, size_t len);
   bool loadFur(unsigned char* file, size_t len, int variantID=0);
   bool loadMod(unsigned char* file, size_t len);
-  bool loadS3M(unsigned char* file, size_t len);
+  bool loadS3M(unsigned char* file, size_t len, bool opl2=false);
   bool loadXM(unsigned char* file, size_t len);
   bool loadIT(unsigned char* file, size_t len);
   bool loadFTM(unsigned char* file, size_t len, bool dnft, bool dnftSig, bool eft);
@@ -688,7 +688,7 @@ class DivEngine {
     void createNew(const char* description, String sysName, bool inBase64=true);
     void createNewFromDefaults();
     // load a file.
-    bool load(unsigned char* f, size_t length, const char* nameHint=NULL);
+    bool load(unsigned char* f, size_t length, const char* nameHint=NULL, bool s3mOPL2=false);
     // play a binary command stream.
     bool playStream(unsigned char* f, size_t length);
     // get the playing stream.

--- a/src/engine/fileOps/fileOpsCommon.cpp
+++ b/src/engine/fileOps/fileOpsCommon.cpp
@@ -19,7 +19,7 @@
 
 #include "fileOpsCommon.h"
 
-bool DivEngine::load(unsigned char* f, size_t slen, const char* nameHint) {
+bool DivEngine::load(unsigned char* f, size_t slen, const char* nameHint, bool s3mOPL2) {
   unsigned char* file;
   size_t len;
   if (slen<21) {
@@ -158,7 +158,7 @@ bool DivEngine::load(unsigned char* f, size_t slen, const char* nameHint) {
     return loadIT(file,len);
   } else if (len>=48) {
     if (memcmp(&file[0x2c],DIV_S3M_MAGIC,4)==0) {
-      return loadS3M(file,len);
+      return loadS3M(file,len,s3mOPL2);
     } else if (memcmp(file,DIV_XM_MAGIC,17)==0) {
       return loadXM(file,len);
     }

--- a/src/engine/fileOps/s3m.cpp
+++ b/src/engine/fileOps/s3m.cpp
@@ -287,7 +287,7 @@ bool DivEngine::loadS3M(unsigned char* file, size_t len) {
       if (hasFM && hasPCM) break;
     }
 
-    int pcmChan=hasFM?9:0;
+    int pcmChan=hasFM?18:0;
     int fmChan=hasPCM?32:0;
     int invalidChan=40;
 
@@ -312,6 +312,20 @@ bool DivEngine::loadS3M(unsigned char* file, size_t len) {
         ds.subsong[0]->chanShow[i]=false;
         ds.subsong[0]->chanShowChanOsc[i]=false;
       }
+
+      if (hasFM) {
+        for (int i=0; i<18; i++) {
+          ds.subsong[0]->chanShow[i]=false;
+          ds.subsong[0]->chanShowChanOsc[i]=false;
+        }
+      }
+    }
+
+    if (hasFM) {
+      for (int i=(hasPCM?32:0) + 9; i<(hasPCM?32:0) + 18; i++) {
+        ds.subsong[0]->chanShow[i]=false;
+        ds.subsong[0]->chanShowChanOsc[i]=false;
+      }
     }
 
     logV("numChans: %d",numChans);
@@ -327,7 +341,7 @@ bool DivEngine::loadS3M(unsigned char* file, size_t len) {
       ds.systemLen++;
     }
     if (hasFM) {
-      ds.system[ds.systemLen]=DIV_SYSTEM_OPL2;
+      ds.system[ds.systemLen]=DIV_SYSTEM_OPL3;
       ds.systemVol[ds.systemLen]=1.0f;
       ds.systemPan[ds.systemLen]=0;
       ds.systemLen++;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -2329,7 +2329,7 @@ int FurnaceGUI::load(String path) {
       return 1;
     }
     fclose(f);
-    if (!e->load(file,(size_t)len,path.c_str())) {
+    if (!e->load(file,(size_t)len,path.c_str(),settings.OPL2s3mImport)) {
       lastError=e->getLastError();
       logE("could not open file!");
       return 1;
@@ -4021,7 +4021,7 @@ bool FurnaceGUI::loop() {
       if (!tutorial.introPlayed || settings.alwaysPlayIntro==3 || (settings.alwaysPlayIntro==2 && curFileName.empty())) {
         unsigned char* introTemp=new unsigned char[intro_fur_len];
         memcpy(introTemp,intro_fur,intro_fur_len);
-        e->load(introTemp,intro_fur_len);
+        e->load(introTemp,intro_fur_len,NULL,settings.OPL2s3mImport);
       }
     }
 

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1962,6 +1962,7 @@ class FurnaceGUI {
     unsigned int maxUndoSteps;
     float vibrationStrength;
     int vibrationLength;
+    bool OPL2s3mImport;
     String mainFontPath;
     String headFontPath;
     String patFontPath;
@@ -2218,6 +2219,7 @@ class FurnaceGUI {
       maxUndoSteps(100),
       vibrationStrength(0.5f),
       vibrationLength(20),
+      OPL2s3mImport(false),
       mainFontPath(""),
       headFontPath(""),
       patFontPath(""),

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -4753,7 +4753,7 @@ void FurnaceGUI::readConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
     settings.vibrationStrength=conf.getFloat("vibrationStrength",0.5f);
     settings.vibrationLength=conf.getInt("vibrationLength",20);
 
-    settings.OPL2s3mImport=conf.getInt("OPL2s3mImport",false);
+    settings.OPL2s3mImport=conf.getBool("OPL2s3mImport",false);
 
     settings.backupEnable=conf.getInt("backupEnable",1);
     settings.backupInterval=conf.getInt("backupInterval",30);

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -1254,6 +1254,14 @@ void FurnaceGUI::drawSettings() {
         }
         popDestColor();
 
+        // SUBSECTION CONFIGURATION
+        CONFIG_SUBSECTION(_("Modules import"));
+        bool s3mOPL2B=settings.OPL2s3mImport;
+        if (ImGui::Checkbox(_("Use OPL2 instead of OPL3 for .s3m modules import"),&s3mOPL2B)) {
+          settings.OPL2s3mImport=s3mOPL2B;
+          settingsChanged=true;
+        }
+
         END_SECTION;
       }
       CONFIG_SECTION(_("Audio")) {
@@ -4745,6 +4753,8 @@ void FurnaceGUI::readConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
     settings.vibrationStrength=conf.getFloat("vibrationStrength",0.5f);
     settings.vibrationLength=conf.getInt("vibrationLength",20);
 
+    settings.OPL2s3mImport=conf.getInt("OPL2s3mImport",false);
+
     settings.backupEnable=conf.getInt("backupEnable",1);
     settings.backupInterval=conf.getInt("backupInterval",30);
     settings.backupMaxCopies=conf.getInt("backupMaxCopies",5);
@@ -5329,6 +5339,8 @@ void FurnaceGUI::writeConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
 
     conf.set("vibrationStrength",settings.vibrationStrength);
     conf.set("vibrationLength",settings.vibrationLength);
+
+    conf.set("OPL2s3mImport",settings.OPL2s3mImport);
 
     conf.set("backupEnable",settings.backupEnable);
     conf.set("backupInterval",settings.backupInterval);


### PR DESCRIPTION
- Use OPL3 instead of OPL2
- Hide all unused channels to not clutter the screen

Why OPL3? Because:
- S3M modules can actually use OPL3 waveforms (see 
[attached file](https://github.com/user-attachments/files/16603412/laamaa_-_keisari_micro.zip) for example)
- OPL3 provides rudimentary panning support. _In order to support soft panning of FM channels it is required to make a new OPL3-based system with 9 channels that internally translates panning & volume data into appropriate TL values for a channel pair that makes up 1 softpanned channel. Too much for just an import._

What else is added:
- Proper channel names (Channel 1, 2, ... for PCM and FM1, 2, ... for FM part), since now PCM channels can start from e.g. Channel 19 which isn't good
- Setting to choose if OPL2 or OPL3 will be used for import. Defaults to OPL3 for accuracy
