### PR TITLE
GUI_ACTION_PAT_ABSORB_INSTRUMENT search through prior orders

### DIFF
--- a/src/gui/doAction.cpp
+++ b/src/gui/doAction.cpp
@@ -677,30 +677,7 @@ void FurnaceGUI::doAction(int what) {
       latchNibble=false;
       break;
     case GUI_ACTION_PAT_ABSORB_INSTRUMENT: {
-      DivPattern* pat=e->curPat[cursor.xCoarse].getPattern(e->curOrders->ord[cursor.xCoarse][curOrder],false);
-      if (!pat) break;
-      bool foundIns=false;
-      bool foundOctave=false;
-      for (int i=cursor.y; i>=0 && !(foundIns && foundOctave); i--) {
-        // absorb most recent instrument
-        if (!foundIns && pat->data[i][2] >= 0) {
-          curIns=pat->data[i][2];
-          foundIns=true;
-        }
-        // absorb most recent octave (i.e. set curOctave such that the "main row" (QWERTY) of notes
-        // will result in an octave number equal to the previous note).
-        if (!foundOctave && pat->data[i][0] != 0) {
-          // decode octave data (was signed cast to unsigned char)
-          int octave=pat->data[i][1];
-          if (octave>128) octave-=256;
-          // @NOTE the special handling when note==12, which is really an octave above what's
-          // stored in the octave data. without this handling, if you press Q, then
-          // "ABSORB_INSTRUMENT", then Q again, you'd get a different octave!
-          if (pat->data[i][0]==12) octave++;
-          curOctave=CLAMP(octave-1, GUI_EDIT_OCTAVE_MIN, GUI_EDIT_OCTAVE_MAX);
-          foundOctave=true;
-        }
-      }
+      doAbsorbInstrument();
       break;
     }
 

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2919,6 +2919,7 @@ class FurnaceGUI {
   void doExpand(int multiplier, const SelectionPoint& sStart, const SelectionPoint& sEnd);
   void doCollapseSong(int divider);
   void doExpandSong(int multiplier);
+  void doAbsorbInstrument();
   void doUndo();
   void doRedo();
   void doFind();


### PR DESCRIPTION
(also set instrument to none if no instrument found, that seems the most appropriate way to "match" the context, but debatable)

Moved to its own function since it was getting slightly big, and add a debug log showing how many orders were searched, as a diagnostic.