### PR TITLE
Apply delayed rows first (fixes #2014)

### DIFF
--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -534,7 +534,7 @@ void DivEngine::processRow(int i, bool afterDelay) {
             bool comparison=(song.delayBehavior==1)?(effectVal<=nextSpeed):(effectVal<(nextSpeed*(curSubSong->timeBase+1)));
             if (song.delayBehavior==2) comparison=true;
             if (comparison) {
-              chan[i].rowDelay=effectVal+1;
+              chan[i].rowDelay=effectVal;
               chan[i].delayOrder=whatOrder;
               chan[i].delayRow=whatRow;
               if (effectVal==nextSpeed) {
@@ -1578,6 +1578,19 @@ bool DivEngine::nextTick(bool noAccum, bool inhibitLowLat) {
     if (--subticks<=0) {
       subticks=tickMult;
 
+      // apply delayed rows before potentially advancing to a new row, which would overwrite the
+      // delayed row's state before it has a chance to do anything. a typical example would be
+      // a delay scheduling a note-on to be simultaneous with the next row, and the next row also
+      // containing a delayed note. if we don't apply the delayed row first, 
+      for (int i=0; i<chans; i++) {
+        // delay effects
+        if (chan[i].rowDelay>0) {
+          if (--chan[i].rowDelay==0) {
+            processRow(i,true);
+          }
+        }
+      }
+
       if (stepPlay!=1) {
         tempoAccum+=(skipping && virtualTempoN<virtualTempoD)?virtualTempoD:virtualTempoN;
         while (tempoAccum>=virtualTempoD) {
@@ -1608,15 +1621,9 @@ bool DivEngine::nextTick(bool noAccum, bool inhibitLowLat) {
         // under no circumstances shall the accumulator become this large
         if (tempoAccum>1023) tempoAccum=1023;
       }
+
       // process stuff
       if (!shallStop) for (int i=0; i<chans; i++) {
-        // delay effects
-        if (chan[i].rowDelay>0) {
-          if (--chan[i].rowDelay==0) {
-            processRow(i,true);
-          }
-        }
-
         // retrigger
         if (chan[i].retrigSpeed) {
           if (--chan[i].retrigTick<0) {


### PR DESCRIPTION
Tick/apply rowDelay prior to stepping forward into `nextRow`.  The only functional difference should be in the case of a delayed row being scheduled simultaneously with another row.

Functional differences:
* prior-row delayed note-ons will still trigger, and they will be heard even if next-row has a note-on if the new note-on is delayed. previously the delayed note-on would not trigger even if the new note-on was delayed.
* next-row commands will "defeat" delayed prior-row commands that are scheduled for the same row (e.g. the result here will be vibrato 0, when previously the prior-row command would "win" and cause vibrato).

<img width="170" alt="Screenshot 2024-08-24 at 11 07 56 AM" src="https://github.com/user-attachments/assets/ecec67c1-424b-4be9-8dca-cdaf6f72ac16">

* if the next-row has a note-on and is not delayed, the new note-on will cancel the delayed on. but this is actually cool -- check this out -- same-tick portamento! actually useful.

<img width="137" alt="Screenshot 2024-08-24 at 11 32 38 AM" src="https://github.com/user-attachments/assets/39ee4304-fd41-451b-9cf2-e0dbec94ebf4">


Caveats
* initially considered addressing retrigger application order too, but it's a very-slightly different case because it needs to be able to trigger same-frame, so it can't just run prior to `nextRow`
* could imagine some unintended side effects that i haven't found
* users may assume that this behavior would/should extend beyond simultaneous execution, to allow simultaneous "in-flight" delayed notes/commands. under the current model this is a misconception, but could be confusing. (i did notice the existence of `std::vector<DivDelayedCommand> delayed;`, which i assume was intended for this type of use case, but that would be "midi-like", almost downright polyphonic!)

<img width="137" alt="image" src="https://github.com/user-attachments/assets/a2134bf8-5dcd-4325-a4ff-20a2e2d38844">