### PR TITLE
Add setting for ctrlWheeling mod (default allows cmd on macos!)

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -424,6 +424,19 @@ void FurnaceGUI::decodeMMLStr(String& source, int* macro, unsigned char& macroLe
     } \
   }
 
+bool FurnaceGUI::isCtrlWheelModifierHeld() const {
+  switch (settings.ctrlWheelModifier) {
+    case 0:
+      return ImGui::IsKeyDown(ImGuiMod_Ctrl) || ImGui::IsKeyDown(ImGuiMod_Super);
+    case 1:
+      return ImGui::IsKeyDown(ImGuiMod_Ctrl);
+    case 2:
+      return ImGui::IsKeyDown(ImGuiMod_Super);
+    default:
+      return false;
+  }
+}
+
 bool FurnaceGUI::CWSliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) {
   flags^=ImGuiSliderFlags_AlwaysClamp;
   if (ImGui::SliderScalar(label,data_type,p_data,p_min,p_max,format,flags)) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -432,6 +432,8 @@ bool FurnaceGUI::isCtrlWheelModifierHeld() const {
       return ImGui::IsKeyDown(ImGuiMod_Ctrl);
     case 2:
       return ImGui::IsKeyDown(ImGuiMod_Super);
+    case 3:
+      return ImGui::IsKeyDown(ImGuiMod_Alt);
     default:
       return false;
   }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -39,7 +39,7 @@
 #define FURNACE_APP_ID "org.tildearrow.furnace"
 
 #define rightClickable if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) ImGui::SetKeyboardFocusHere(-1);
-#define ctrlWheeling ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && wheelY!=0)
+#define ctrlWheeling (isCtrlWheelModifierHeld() && wheelY!=0)
 
 #define handleUnimportant if (settings.insFocusesPattern && patternOpen) {nextWindow=GUI_WINDOW_PATTERN;}
 #define unimportant(x) if (x) {handleUnimportant}
@@ -1804,6 +1804,7 @@ class FurnaceGUI {
     int patRowsBase;
     int orderRowsBase;
     int soloAction;
+    int ctrlWheelModifier;
     int pullDeleteBehavior;
     int wrapHorizontal;
     int wrapVertical;
@@ -2063,6 +2064,7 @@ class FurnaceGUI {
       patRowsBase(0),
       orderRowsBase(1),
       soloAction(0),
+      ctrlWheelModifier(0),
       pullDeleteBehavior(1),
       wrapHorizontal(0),
       wrapVertical(0),
@@ -2738,6 +2740,7 @@ class FurnaceGUI {
   static bool LocalizedComboGetter(void* data, int idx, const char** out_text);
 
   // these ones offer ctrl-wheel fine value changes.
+  bool isCtrlWheelModifierHeld() const;
   bool CWSliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format=NULL, ImGuiSliderFlags flags=0);
   bool CWVSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format=NULL, ImGuiSliderFlags flags=0);
   bool CWSliderInt(const char* label, int* v, int v_min, int v_max, const char* format="%d", ImGuiSliderFlags flags=0);

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -2720,6 +2720,22 @@ void FurnaceGUI::drawSettings() {
         }
         ImGui::Unindent();
 
+        ImGui::Text(_("Modifier for alternate wheel-scrolling (vertical/zoom/slider-input):"));
+        ImGui::Indent();
+        if (ImGui::RadioButton(_("Ctrl or Meta/Cmd##cwm1"),settings.ctrlWheelModifier==0)) {
+          settings.ctrlWheelModifier=0;
+          settingsChanged=true;
+        }
+        if (ImGui::RadioButton(_("Ctrl##cwm2"),settings.ctrlWheelModifier==1)) {
+          settings.ctrlWheelModifier=1;
+          settingsChanged=true;
+        }
+        if (ImGui::RadioButton(_("Meta/Cmd##cwm3"),settings.ctrlWheelModifier==2)) {
+          settings.ctrlWheelModifier=2;
+          settingsChanged=true;
+        }
+        ImGui::Unindent();
+
         bool doubleClickColumnB=settings.doubleClickColumn;
         if (ImGui::Checkbox(_("Double click selects entire column"),&doubleClickColumnB)) {
           settings.doubleClickColumn=doubleClickColumnB;
@@ -4819,6 +4835,7 @@ void FurnaceGUI::readConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
 
   if (groups&GUI_SETTINGS_BEHAVIOR) {
     settings.soloAction=conf.getInt("soloAction",0);
+    settings.ctrlWheelModifier=conf.getInt("ctrlWheelModifier",0);
     settings.pullDeleteBehavior=conf.getInt("pullDeleteBehavior",1);
     settings.wrapHorizontal=conf.getInt("wrapHorizontal",0);
     settings.wrapVertical=conf.getInt("wrapVertical",0);
@@ -5117,6 +5134,7 @@ void FurnaceGUI::readConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
   clampSetting(settings.patRowsBase,0,1);
   clampSetting(settings.orderRowsBase,0,1);
   clampSetting(settings.soloAction,0,2);
+  clampSetting(settings.ctrlWheelModifier,0,2);
   clampSetting(settings.pullDeleteBehavior,0,1);
   clampSetting(settings.wrapHorizontal,0,2);
   clampSetting(settings.wrapVertical,0,3);
@@ -5404,6 +5422,7 @@ void FurnaceGUI::writeConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
   // behavior
   if (groups&GUI_SETTINGS_BEHAVIOR) {
     conf.set("soloAction",settings.soloAction);
+    conf.set("ctrlWheelModifier",settings.ctrlWheelModifier);
     conf.set("pullDeleteBehavior",settings.pullDeleteBehavior);
     conf.set("wrapHorizontal",settings.wrapHorizontal);
     conf.set("wrapVertical",settings.wrapVertical);

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -2734,6 +2734,11 @@ void FurnaceGUI::drawSettings() {
           settings.ctrlWheelModifier=2;
           settingsChanged=true;
         }
+        // technically this key is called Option on mac, but we call it Alt in getKeyName(s)
+        if (ImGui::RadioButton(_("Alt##cwm4"),settings.ctrlWheelModifier==3)) {
+          settings.ctrlWheelModifier=3;
+          settingsChanged=true;
+        }
         ImGui::Unindent();
 
         bool doubleClickColumnB=settings.doubleClickColumn;
@@ -5134,7 +5139,7 @@ void FurnaceGUI::readConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
   clampSetting(settings.patRowsBase,0,1);
   clampSetting(settings.orderRowsBase,0,1);
   clampSetting(settings.soloAction,0,2);
-  clampSetting(settings.ctrlWheelModifier,0,2);
+  clampSetting(settings.ctrlWheelModifier,0,3);
   clampSetting(settings.pullDeleteBehavior,0,1);
   clampSetting(settings.wrapHorizontal,0,2);
   clampSetting(settings.wrapVertical,0,3);


### PR DESCRIPTION
Defaults to allow either ctrl or super/win/cmd, but can choose to allow only ctrl or only super/win/cmd.

I don't know if anybody would change this from default, so worth considering whether it should be a setting or not?  If it were just me I'd say it's better without the setting, since it'll be more future-proof (if another action is added that uses a different modifier + scroll-wheel, we can make modifiers more specific as needed, without breaking a user setting etc)