### PR TITLE
In command palette, sort matches by quality/exactness

### DIFF
--- a/src/gui/commandPalette.cpp
+++ b/src/gui/commandPalette.cpp
@@ -32,7 +32,6 @@
 // but disabling until further thought/discussion.
 // #define MATCH_SCORE_PREFER_LOWER_CHARS_AFTER_NEEDLE
 
-// negative is failure (doesn't contain needle), 0 is perfect (exactly matches needle),
 struct MatchScore {
   bool valid=true;
   enum Cost { COST_BEFORE_NEEDLE, COST_WITHIN_NEEDLE, COST_AFTER_NEEDLE, COST_COUNT };
@@ -45,7 +44,6 @@ struct MatchScore {
   }
 
   static bool IsFirstPreferable(const MatchScore& a, const MatchScore& b) {
-    if(1) return false;
     auto PreferenceForAAmount=[&](Cost cost) {
       // prefer a if lower cost
       return b.costs[cost]-a.costs[cost];

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1604,10 +1604,11 @@ class FurnaceGUI {
   String mmlStringSNES[DIV_MAX_CHIPS];
   String folderString;
 
+  struct PaletteSearchResult { int id; std::vector<int> highlightChars; };
   std::vector<DivSystem> sysSearchResults;
   std::vector<std::pair<DivSample*,bool>> sampleBankSearchResults;
   std::vector<FurnaceGUISysDef> newSongSearchResults;
-  std::vector<int> paletteSearchResults;
+  std::vector<PaletteSearchResult> paletteSearchResults;
   FixedQueue<String,32> recentFile;
   std::vector<DivInstrumentType> makeInsTypeList;
   std::vector<FurnaceGUIWaveSizeEntry> waveSizeList;


### PR DESCRIPTION
This one sort of speaks for itself if you look at the images.  But in brief, this change sorts the command palette results according to closeness to your search term.

### After this change

<img width="335" alt="Screenshot 2024-08-27 at 12 56 57 AM" src="https://github.com/user-attachments/assets/35165cb5-10da-497d-a5cc-2356b66bd468">

A search for "int" yields "interpolate".  Reasonable, that's the only one of the options that actually matches, the others are only fuzzy matches.  This is a nice quick way of using the keyboard to get to the interpolate action.

### Before this change

<img width="345" alt="Screenshot 2024-08-27 at 12 57 47 AM" src="https://github.com/user-attachments/assets/4ce4e87e-a1f3-4e8f-85c2-16fa0727c826">

A search for "int" doesn't yield any results in the first page that even contain "int"!

<img width="333" alt="Screenshot 2024-08-27 at 12 58 13 AM" src="https://github.com/user-attachments/assets/96b339e3-b77f-485b-a911-4ed1078de4c6">

Even if you expand the search to "inter", "interpolate" is still toward the bottom.  This isn't very helpful.

### Details

The specific "cost/score" function has two factors:
* Number of characters interleaved within the search term (i.e. searching for "int", the term "ionot" would have a cost of 2, whereas "innt" would have a cost of 1 and thus win).  This is the most important score since it reflects the exactness of the match.
* In the case of a tie in the above score, it uses the number of characters preceding the search term, which helps particularly with short search terms.  e.g. "Ease" appears in "increase", but it's probably more relevant to put an action that starts with "Ease" at the top of the search.

Further tie-breaking can be done (I experimented with counting characters after the end of the search term) but doesn't seem relevant (below a certain signal-to-noise-ratio, at a certain point the consistency of the original ordering becomes more valuable than seemingly random tie-breaks).

### Caveats

I think this is definitely a good and simple change, but there is a weakness I noted in how I'm calculating the score -- it's using a greedy search, i.e. it considers the needle "found" in the haystack as soon as it encounters its first character, even if the full needle might be found perfectly intact later in the haystack.  e.g. searching for "hello" in "hippohello" would be considered to have 5 chars interleaved in the search term ("ippoh"), when it would be more accurate to say it has a perfect match score of 0 because "hello" appears in it directly.

I haven't run into issues with this in practice, but I'd consider it an open area for future improvement.