### PR TITLE
ZSM: exclude keydown events on loop lookahead

### DIFF
--- a/src/engine/export/zsm.cpp
+++ b/src/engine/export/zsm.cpp
@@ -674,7 +674,10 @@ void DivExportZSM::run() {
         if (writes.size()>0)
           logD("zsmOps: Writing %d messages to chip %d",writes.size(),i);
         for (DivRegWrite& write: writes) {
-          if (i==YM) zsm.writeYM(write.addr&0xff,write.val);
+          if (i==YM) {
+            if (done && write.addr==0x08 && (write.val&0x78)>0) continue; // don't process keydown on lookahead
+            zsm.writeYM(write.addr&0xff,write.val);
+          }
           if (i==VERA) {
             if (done && write.addr>=64) continue; // don't process any PCM or sync events on the loop lookahead
             zsm.writePSG(write.addr&0xff,write.val);


### PR DESCRIPTION
Previously, the loop point lookahead would write out all events to the end of the ZSM before returning to the loop point.  This is needed to capture state that existed on the first playthrough but did not change on the tick of the loop point.

In most cases, the second triggering via keydown/keyup/keydown within the same tick at the loop point was not audible, but for some instruments and some situations, this __is__ audible, which this PR is meant to address.