### PR TITLE
Add "not all PRs will be accepted" to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,19 @@
 # Contributing
 
-contributions to Furnace are welcome!
-
-# Issue reports
+## Issue reports
 
 if you find an issue with Furnace, see the Issues section.
 
-# Suggestions and other types of discussions
+## Suggestions and other types of discussions
 
 see the Discussions section.
-
 **DO NOT USE THE ISSUES SECTION FOR THESE - it is only for ISSUES.**
+
+## Code contributions
+
+Furnace is currently a "solo/monarchy"-led project, rather than community-led (https://wackowiki.org/doc/Org/Articles/5TypesOpenSourceProjects is a nice reference). While contributions are often welcome and appreciated, not all features will be accepted (for example if the maintainer(s) feel they're out of scope or add too much complexity).
+
+tildearrow (project author) holds full discretion over what goes into this repo, so please understand that there's <ins>no guarantee any PR will be accepted, or reviewed within a particular timeframe</ins>. That said, many great features/chips/fixes have come from the community, so please feel free to get involved!
 
 # Other
 


### PR DESCRIPTION
Having code contribution policy written down explicitly (even if people don't read it) should help conversations about PR status go more smoothly when there's contention. And if people do read it before coding, even better!

This was my attempt to sum up the current code contribution policy.
