### PR TITLE
fix: volume portamento was canceling out volume column in some cases

### DIFF
--- a/src/engine/cmdStream.cpp
+++ b/src/engine/cmdStream.cpp
@@ -364,6 +364,7 @@ bool DivCSPlayer::tick() {
     }
 
     if (sendVolume || chan[i].volSpeed!=0) {
+      int preSpeedVol=chan[i].volume;
       chan[i].volume+=chan[i].volSpeed;
       if (chan[i].volSpeedTarget!=-1) {
         bool atTarget=false;
@@ -377,7 +378,11 @@ bool DivCSPlayer::tick() {
         }
 
         if (atTarget) {
-          chan[i].volume=chan[i].volSpeedTarget;
+          if (chan[i].volSpeed>0) {
+            chan[i].volume=MAX(preSpeedVol,chan[i].volSpeedTarget);
+          } else if (chan[i].volSpeed<0) {
+            chan[i].volume=MIN(preSpeedVol,chan[i].volSpeedTarget);
+          }
           chan[i].volSpeed=0;
           chan[i].volSpeedTarget=-1;
         }

--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -1632,6 +1632,7 @@ bool DivEngine::nextTick(bool noAccum, bool inhibitLowLat) {
         if (!song.noSlidesOnFirstTick || !firstTick) {
           if (chan[i].volSpeed!=0) {
             chan[i].volume=(chan[i].volume&0xff)|(dispatchCmd(DivCommand(DIV_CMD_GET_VOLUME,i))<<8);
+            int preSpeedVol=chan[i].volume;
             chan[i].volume+=chan[i].volSpeed;
             if (chan[i].volSpeedTarget!=-1) {
               bool atTarget=false;
@@ -1645,7 +1646,11 @@ bool DivEngine::nextTick(bool noAccum, bool inhibitLowLat) {
               }
 
               if (atTarget) {
-                chan[i].volume=chan[i].volSpeedTarget;
+                if (chan[i].volSpeed>0) {
+                  chan[i].volume=MAX(preSpeedVol,chan[i].volSpeedTarget);
+                } else if (chan[i].volSpeed<0) {
+                  chan[i].volume=MIN(preSpeedVol,chan[i].volSpeedTarget);
+                }
                 chan[i].volSpeed=0;
                 chan[i].volSpeedTarget=-1;
                 dispatchCmd(DivCommand(DIV_CMD_HINT_VOLUME,i,chan[i].volume>>8));


### PR DESCRIPTION
in case where volume portamento was active but not complete, using the volume column to set volume to a point past the volume portamento target would be detected as "volume portamento complete" and set volume to the vol porta target, even if the vol porta target was actually lower/higher than the volume set by the volume command

example case below: on row 0x2 the volume gets set to F, but due to the bug the result is that the volume gets set to 2. on row 0x6 is the same case but using the current workaround if clearing the vol porta target via `D300`.  with the fix, row 0x2 correctly causes volume F
<img width="127" alt="Screenshot 2024-09-06 at 3 48 28 PM" src="https://github.com/user-attachments/assets/8d730c6d-f2d3-412f-a607-e32dcb20c6d0">
