### PR TITLE
update D4xx to be slower (down from 256x to 16x), rename D3xx to be "fine"

### DIFF
--- a/doc/3-pattern/effects.md
+++ b/doc/3-pattern/effects.md
@@ -15,9 +15,9 @@ however, effects are continuous (unless specified), which means you only need to
 - `F8xx`: **Single tick volume up.** adds `x` to volume.
 - `F9xx`: **Single tick volume down.** subtracts `x` from volume.
   - ---
-- `D3xx`: **Volume portamento.** slides the volume to the one specified in the volume column. `x` is the slide speed.
+- `D3xx`: **Volume portamento (fine).** slides the volume to the value specified in the volume column. `x` is the slide speed, in units identical to those used by `F3xx`/`F4xx` (fine volume slide up/down).
   - a volume _must_ be present with this effect for it to work.
-- `D4xx`: **Volume portamento (fast).** like `D3xx` but 4× faster.
+- `D4xx`: **Volume portamento.** same as `D3xx` but 16× faster. (i.e. `D4F0` is the same speed as `FA0F`/`FAF0`).
   - ---
 - `07xy`: **Tremolo.** changes volume to be "wavy" with a sine LFO. `x` is the speed. `y` is the depth.
   - tremolo is downward only.

--- a/src/engine/playback.cpp
+++ b/src/engine/playback.cpp
@@ -963,7 +963,7 @@ void DivEngine::processRow(int i, bool afterDelay) {
           chan[i].cutType=0;
         }
         break;
-      case 0xd3: // volume portamento (vol porta)
+      case 0xd3: // volume portamento (vol porta fine))
         // tremolo and vol slides are incompatible
         chan[i].tremoloDepth=0;
         chan[i].tremoloRate=0;
@@ -971,11 +971,11 @@ void DivEngine::processRow(int i, bool afterDelay) {
         chan[i].volSpeedTarget=chan[i].volSpeed==0 ? -1 : volPortaTarget;
         dispatchCmd(DivCommand(DIV_CMD_HINT_VOL_SLIDE_TARGET,i,chan[i].volSpeed,chan[i].volSpeedTarget));
         break;
-      case 0xd4: // volume portamento fast (vol porta fast)
+      case 0xd4: // volume portamento (vol porta)
         // tremolo and vol slides are incompatible
         chan[i].tremoloDepth=0;
         chan[i].tremoloRate=0;
-        chan[i].volSpeed=volPortaTarget<0 ? 0 : volPortaTarget>chan[i].volume ? 256*effectVal : -256*effectVal;
+        chan[i].volSpeed=volPortaTarget<0 ? 0 : volPortaTarget>chan[i].volume ? 16*effectVal : -16*effectVal;
         chan[i].volSpeedTarget=chan[i].volSpeed==0 ? -1 : volPortaTarget;
         dispatchCmd(DivCommand(DIV_CMD_HINT_VOL_SLIDE_TARGET,i,chan[i].volSpeed,chan[i].volSpeedTarget));
         break;


### PR DESCRIPTION
previously D4xx slide speed matched FAxy, but given that D4 effect values can be over 16x larger than FAxy values, it lacked in resolution, with most of its range consumed in not-so-useful values.

now D410 matches FA01/FA10, so it's familiar and has the same range as FAxy, while still having 4x the resolution of 0Axy. this is accomplished by having D4 give 4x the speed of D3.

have renamed D3xx to be "fine" since it matches the speed of the fine volume slides (F3xx/F4xx)