### PR TITLE
Add "from/to" option to "change instrument.." menu

### DIFF
--- a/src/gui/editing.cpp
+++ b/src/gui/editing.cpp
@@ -1307,7 +1307,7 @@ void FurnaceGUI::doPaste(PasteMode mode, int arg, bool readClipboard, String cli
   }
 }
 
-void FurnaceGUI::doChangeIns(int ins) {
+void FurnaceGUI::doChangeIns(int ins, int insFrom) {
   finishSelection();
   prepareUndo(GUI_UNDO_PATTERN_CHANGE_INS);
 
@@ -1317,7 +1317,9 @@ void FurnaceGUI::doChangeIns(int ins) {
     DivPattern* pat=e->curPat[iCoarse].getPattern(e->curOrders->ord[iCoarse][curOrder],true);
     for (int j=selStart.y; j<=selEnd.y; j++) {
       if (pat->data[j][2]!=-1 || !((pat->data[j][0]==0 || pat->data[j][0]==100 || pat->data[j][0]==101 || pat->data[j][0]==102) && pat->data[j][1]==0)) {
-        pat->data[j][2]=ins;
+        if (insFrom==-1 || (pat->data[j][2]==-1 || pat->data[j][2]==insFrom)) {
+          pat->data[j][2]=ins;
+        }
       }
     }
   }

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -3107,10 +3107,25 @@ void FurnaceGUI::editOptions(bool topMenu) {
     if (e->song.ins.empty()) {
       ImGui::Text(_("no instruments available"));
     }
-    for (size_t i=0; i<e->song.ins.size(); i++) {
-      snprintf(id,4095,"%.2X: %s",(int)i,e->song.ins[i]->name.c_str());
+    if (ImGui::BeginMenu(_("from:"))) {
+      for (size_t fromIdx=0; fromIdx<e->song.ins.size(); fromIdx++) {
+        snprintf(id,4095,"from %.2X: %s##insFrom",(int)fromIdx,e->song.ins[fromIdx]->name.c_str());
+        if (ImGui::BeginMenu(id)) {
+          for (size_t toIdx=0; toIdx<e->song.ins.size(); toIdx++) {
+            snprintf(id,4095,"to %.2X: %s",(int)toIdx,e->song.ins[toIdx]->name.c_str());
+            if (ImGui::MenuItem(id)) {
+              doChangeIns(toIdx,fromIdx);
+            }
+          }
+          ImGui::EndMenu();
+        }
+      }
+      ImGui::EndMenu();
+    }
+    for (size_t toIdx=0; toIdx<e->song.ins.size(); toIdx++) {
+      snprintf(id,4095,"%.2X: %s",(int)toIdx,e->song.ins[toIdx]->name.c_str());
       if (ImGui::MenuItem(id)) {
-        doChangeIns(i);
+        doChangeIns(toIdx);
       }
     }
     ImGui::EndMenu();

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2933,7 +2933,7 @@ class FurnaceGUI {
   void doPasteFurnace(PasteMode mode, int arg, bool readClipboard, String clipb, std::vector<String> data, int startOff, bool invalidData, UndoRegion ur);
   void doPasteMPT(PasteMode mode, int arg, bool readClipboard, String clipb, std::vector<String> data, int mptFormat, UndoRegion ur);
   void doPaste(PasteMode mode=GUI_PASTE_MODE_NORMAL, int arg=0, bool readClipboard=true, String clipb="");
-  void doChangeIns(int ins);
+  void doChangeIns(int ins, int insFrom=-1);
   void doInterpolate();
   void doFade(int p0, int p1, bool mode);
   void doInvertValues();


### PR DESCRIPTION
Keeping existing functionality the same, now allows selectively converting instrument X values to instrument Y (very common need in my experience)

implemented as a multi-level menu (pick your "from" then pick your "to")
<img width="846" alt="Screenshot 2024-09-07 at 5 33 39 PM" src="https://github.com/user-attachments/assets/ee4fc159-a0aa-4089-8188-d3a9c5770863">
