### PR TITLE
Add handy preset buttons to "scale..." menu

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -3157,6 +3157,14 @@ void FurnaceGUI::editOptions(bool topMenu) {
       doScale(scaleMax);
       ImGui::CloseCurrentPopup();
     }
+    if (ImGui::Button(_("Scale 200%"))) { doScale(200.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 150%"))) { doScale(150.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 125%"))) { doScale(125.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 110%"))) { doScale(110.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 90%"))) { doScale(90.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 80%"))) { doScale(80.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 75%"))) { doScale(75.0f); ImGui::CloseCurrentPopup(); }
+    if (ImGui::Button(_("Scale 50%"))) { doScale(50.0f); ImGui::CloseCurrentPopup(); }
     ImGui::EndMenu();
   }
   if (ImGui::BeginMenu(_("randomize..."))) {


### PR DESCRIPTION
i typically dread using "scale..." because it's inconvenient (i'm in "mouse mode" and don't want to have to select and type, and it takes a lot of clicks to use the +/- buttons).  at the same time, i'm generally not looking for precision.  hence, adding some buttons for scaling common multipliers.

<img width="606" alt="Screenshot 2024-09-07 at 5 45 40 PM" src="https://github.com/user-attachments/assets/b9e11635-13cf-45e6-90d2-a21749de1b0a">
