### PR TITLE
Macro editor: add "use longest macro length" horizontal scaling option, show macro length in "Single" mode

### DIFF
--- a/doc/2-interface/settings.md
+++ b/doc/2-interface/settings.md
@@ -508,7 +508,7 @@ below all the binds, select a key from the dropdown list to add it. it will appe
 - **Macro step size/horizontal zoom:**
   - **Manual**
   - **Automatic per macro**
-  - **Automatic (use longest macro)
+  - **Automatic (use longest macro)**
 
 ### Wave Editor
 

--- a/doc/2-interface/settings.md
+++ b/doc/2-interface/settings.md
@@ -505,7 +505,10 @@ below all the binds, select a key from the dropdown list to add it. it will appe
   - **Grid**
   - **Single (with list)**
 - **Use classic macro editor vertical slider**
-- **Automatic macro step size/horizontal zoom**
+- **Macro step size/horizontal zoom:**
+  - **Manual**
+  - **Automatic per macro**
+  - **Automatic (use longest macro)
 
 ### Wave Editor
 

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -1780,7 +1780,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
             if ((i.macro->vScroll+i.macro->vZoom)>(i.max-i.min)) {
               i.macro->vScroll=(i.max-i.min)-i.macro->vZoom;
             }
-          } else if (!settings.autoMacroStepSize) {
+          } else if (settings.autoMacroStepSize==0) {
             macroPointSize+=wheelY;
             if (macroPointSize<1) macroPointSize=1;
             if (macroPointSize>256) macroPointSize=256;
@@ -2148,6 +2148,8 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
 
 void FurnaceGUI::drawMacros(std::vector<FurnaceGUIMacroDesc>& macros, FurnaceGUIMacroEditState& state) {
   int index=0;
+  int maxMacroLen = 0;
+  for (FurnaceGUIMacroDesc& macro : macros) { maxMacroLen = MAX(maxMacroLen, macro.macro->len); }
   float reservedSpace=(settings.oldMacroVSlider)?(20.0f*dpiScale+ImGui::GetStyle().ItemSpacing.x):ImGui::GetStyle().ScrollbarSize;
   switch (settings.macroLayout) {
     case 0: {
@@ -2163,7 +2165,7 @@ void FurnaceGUI::drawMacros(std::vector<FurnaceGUIMacroDesc>& macros, FurnaceGUI
         ImGui::TableNextColumn();
         float lenAvail=ImGui::GetContentRegionAvail().x;
         //ImGui::Dummy(ImVec2(120.0f*dpiScale,dpiScale));
-        if (!settings.autoMacroStepSize) {
+        if (settings.autoMacroStepSize==0) {
           ImGui::SetNextItemWidth(120.0f*dpiScale);
           if (ImGui::InputInt("##MacroPointSize",&macroPointSize,1,4)) {
             if (macroPointSize<1) macroPointSize=1;
@@ -2174,11 +2176,13 @@ void FurnaceGUI::drawMacros(std::vector<FurnaceGUIMacroDesc>& macros, FurnaceGUI
         float availableWidth=ImGui::GetContentRegionAvail().x-reservedSpace;
         int totalFit=MIN(255,availableWidth/MAX(1,macroPointSize*dpiScale));
         int scrollMax=0;
-        if (settings.autoMacroStepSize) totalFit=1;
+        if (settings.autoMacroStepSize!=0) totalFit=1;
         for (FurnaceGUIMacroDesc& i: macros) {
           if (i.macro->len>scrollMax) scrollMax=i.macro->len;
-          if (settings.autoMacroStepSize) {
+          if (settings.autoMacroStepSize==1) {
             if ((i.macro->open&6)==0 && totalFit<i.macro->len) totalFit=i.macro->len;
+          } else if (settings.autoMacroStepSize==2) {
+            if ((i.macro->open&6)==0 && totalFit<maxMacroLen) totalFit=maxMacroLen;
           }
         }
         scrollMax-=totalFit;
@@ -2333,7 +2337,23 @@ void FurnaceGUI::drawMacros(std::vector<FurnaceGUIMacroDesc>& macros, FurnaceGUI
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         for (size_t i=0; i<macros.size(); i++) {
-          if (ImGui::Selectable(macros[i].displayName,state.selectedMacro==(int)i)) {
+          // include macro len if non-zero, making particularly clear at-a-glance which macros
+          // have non-zero len (i.e. are active). and calculate how big we need to be to leave some
+          // extra space so the column doesn't change size when len is changed under typical
+          // circumstances (really don't want to move buttons while mouse is being clicked or held).
+          char buf[256];
+          snprintf(buf, sizeof(buf)/sizeof(char), "%s [%d]", macros[i].displayName, 99);
+          float stretchX=ImGui::CalcTextSize(buf).x;
+
+          if (macros[i].macro->len>0) {
+            snprintf(buf, sizeof(buf)/sizeof(char), "%s [%d]", macros[i].displayName, macros[i].macro->len);
+          } else {
+            snprintf(buf, sizeof(buf)/sizeof(char), "%s", macros[i].displayName);
+          }
+
+          ImVec2 size=ImGui::CalcTextSize(buf);
+          size.x=MAX(stretchX, size.x);
+          if (ImGui::Selectable(buf,state.selectedMacro==(int)i,0,size)) {
             state.selectedMacro=i;
           }
         }
@@ -2359,7 +2379,8 @@ void FurnaceGUI::drawMacros(std::vector<FurnaceGUIMacroDesc>& macros, FurnaceGUI
           for (FurnaceGUIMacroDesc& i: macros) {
             if (i.macro->len>scrollMax) scrollMax=i.macro->len;
           }
-          if (settings.autoMacroStepSize) totalFit=MAX(1,m.macro->len);
+          if (settings.autoMacroStepSize==1) totalFit=MAX(1,m.macro->len);
+          else if (settings.autoMacroStepSize==2) totalFit=MAX(1,maxMacroLen);
           scrollMax-=totalFit;
           if (scrollMax<0) scrollMax=0;
           if (macroDragScroll>scrollMax) {
@@ -2373,7 +2394,7 @@ void FurnaceGUI::drawMacros(std::vector<FurnaceGUIMacroDesc>& macros, FurnaceGUI
           }
           ImGui::EndDisabled();
 
-          if (!settings.autoMacroStepSize) {
+          if (settings.autoMacroStepSize==0) {
             ImGui::SameLine();
             ImGui::Button(ICON_FA_SEARCH_PLUS "##MacroZoomB");
             if (ImGui::BeginPopupContextItem("MacroZoomP",ImGuiPopupFlags_MouseButtonLeft)) {

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -3640,11 +3640,21 @@ void FurnaceGUI::drawSettings() {
         }
 
         ImGui::BeginDisabled(settings.macroLayout==2);
-        bool autoMacroStepSizeB=settings.autoMacroStepSize;
-        if (ImGui::Checkbox(_("Automatic macro step size/horizontal zoom"),&autoMacroStepSizeB)) {
-          settings.autoMacroStepSize=autoMacroStepSizeB;
+        ImGui::Text(_("Macro step size/horizontal zoom:"));
+        ImGui::Indent();
+        if (ImGui::RadioButton(_("Manual"),settings.autoMacroStepSize==0)) {
+          settings.autoMacroStepSize=0;
           settingsChanged=true;
         }
+        if (ImGui::RadioButton(_("Automatic per macro"),settings.autoMacroStepSize==1)) {
+          settings.autoMacroStepSize=1;
+          settingsChanged=true;
+        }
+        if (ImGui::RadioButton(_("Automatic (use longest macro)"),settings.autoMacroStepSize==2)) {
+          settings.autoMacroStepSize=2;
+          settingsChanged=true;
+        }
+        ImGui::Unindent();
         ImGui::EndDisabled();
 
         // SUBSECTION WAVE EDITOR
@@ -5295,7 +5305,7 @@ void FurnaceGUI::readConfig(DivConfig& conf, FurnaceGUISettingGroups groups) {
   clampSetting(settings.backupInterval,10,86400);
   clampSetting(settings.backupMaxCopies,1,100);
   clampSetting(settings.autoFillSave,0,1);
-  clampSetting(settings.autoMacroStepSize,0,1);
+  clampSetting(settings.autoMacroStepSize,0,2);
   clampSetting(settings.s3mOPL3,0,1);
 
   if (settings.exportLoops<0.0) settings.exportLoops=0.0;


### PR DESCRIPTION
* extend "autoMacroStepSize" setting to include an option to set the horizontal scale in the macro view based on the longest macro (of the current tab). this means that you'll have a consistent horizontal scale across all the macros, rather than changing for each macro. existing options are unaffected.

<img width="329" alt="Screenshot 2024-09-11 at 11 51 22 AM" src="https://github.com/user-attachments/assets/f962871e-d36d-45ee-ab8f-3a94d46b867f">

...

* in "single" macro view, i noticed that there was no way of knowing which macros were actually being used (i.e. non-zero len) without selecting each of them individually and then trying to remember. so i added a len readout per macro to the listing.

<img width="579" alt="Screenshot 2024-09-11 at 11 51 09 AM" src="https://github.com/user-attachments/assets/b9a96e5f-e06d-4698-b645-3fee34ecf7aa">

(this image also shows the "use longest macro" setting -- the automatic horizontal scale is based on pitch [6] instead of volume [5], even though volume [5] is what's selected)
