### PR TITLE
Add horizontal list mode support to wavetable list

### DIFF
--- a/doc/2-interface/settings.md
+++ b/doc/2-interface/settings.md
@@ -488,7 +488,7 @@ below all the binds, select a key from the dropdown list to add it. it will appe
 
 - **Unified instrument/wavetable/sample list**: combines all three types of assets into one list.
   - the buttons act as appropriate to the currently selected asset or header.
-- **Horizontal instrument list**: when there are more instruments than there is room to display them...
+- **Horizontal instrument/wavetable list**: when there are more instruments/wavetables than there is room to display them...
   - if on, scroll horizontally through multiple columns.
   - if off, scroll vertically in one long column.
   - only appears if "Unified instrument/wavetable/sample list" is off.

--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -997,8 +997,7 @@ void FurnaceGUI::drawSampleList(bool asChild) {
   }
 }
 
-template <typename func_waveItemData>
-void FurnaceGUI::waveListHorizontalGroup(float* wavePreview, int dir, int count, const func_waveItemData& waveItemData) {
+template <typename func_waveItemData> void FurnaceGUI::waveListHorizontalGroup(float* wavePreview, int dir, int count, const func_waveItemData& waveItemData) {
   if (count==0) return;
 
   float idealWidthMin=225.0f*dpiScale;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2817,6 +2817,8 @@ class FurnaceGUI {
   void actualWaveList();
   void actualSampleList();
 
+  template <typename func_waveItemData>
+  void waveListHorizontalGroup(float* wavePreview, int dir, int count, const func_waveItemData& waveItemData);
   void insListItem(int index, int dir, int asset);
   void waveListItem(int index, float* wavePreview, int dir, int asset);
   void sampleListItem(int index, int dir, int asset);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2817,8 +2817,7 @@ class FurnaceGUI {
   void actualWaveList();
   void actualSampleList();
 
-  template <typename func_waveItemData>
-  void waveListHorizontalGroup(float* wavePreview, int dir, int count, const func_waveItemData& waveItemData);
+  template <typename func_waveItemData> void waveListHorizontalGroup(float* wavePreview, int dir, int count, const func_waveItemData& waveItemData);
   void insListItem(int index, int dir, int asset);
   void waveListItem(int index, float* wavePreview, int dir, int asset);
   void sampleListItem(int index, int dir, int asset);

--- a/src/gui/settings.cpp
+++ b/src/gui/settings.cpp
@@ -3575,7 +3575,7 @@ void FurnaceGUI::drawSettings() {
 
         ImGui::BeginDisabled(settings.unifiedDataView);
         bool horizontalDataViewB=settings.horizontalDataView;
-        if (ImGui::Checkbox(_("Horizontal instrument list"),&horizontalDataViewB)) {
+        if (ImGui::Checkbox(_("Horizontal instrument/wavetable list"),&horizontalDataViewB)) {
           settings.horizontalDataView=horizontalDataViewB;
           settingsChanged=true;
         }


### PR DESCRIPTION
No new setting, considered an extension of the existing horizontal list setting that previously applied only to instrument list.

Video shows how it functions under all the various permutations of relevant settings I could find.

https://github.com/user-attachments/assets/4f43885f-7f78-468c-ba94-ff7ab6cc533d

