### PR TITLE
fix #2182

### DIFF
--- a/src/gui/editControls.cpp
+++ b/src/gui/editControls.cpp
@@ -1020,7 +1020,7 @@ void FurnaceGUI::drawEditControls() {
         ImGui::SameLine();
         if (ImGui::Button(ICON_FA_PLAY_CIRCLE "##PlayAgain")) {
           e->setRepeatPattern(false);
-          play();
+          play(0);
         }
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip(_("Play from the beginning of this pattern"));
@@ -1028,7 +1028,7 @@ void FurnaceGUI::drawEditControls() {
         ImGui::SameLine();
         if (ImGui::Button(ICON_FA_STEP_FORWARD "##PlayRepeat")) {
           e->setRepeatPattern(true);
-          play();
+          play(0);
         }
         if (ImGui::IsItemHovered()) {
           ImGui::SetTooltip(_("Repeat from the beginning of this pattern"));

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1229,7 +1229,7 @@ void FurnaceGUI::play(int row) {
   memset(lastIns,-1,sizeof(int)*DIV_MAX_CHANS);
   if (followPattern) makeCursorUndo();
   if (!followPattern) e->setOrder(curOrder);
-  if (row>0) {
+  if (row>=0) {
     if (!e->playToRow(row)) {
       showError(_("the song is over!"));
     }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2993,7 +2993,7 @@ class FurnaceGUI {
   void doUndoInstrument();
   void doRedoInstrument();
 
-  void play(int row=0);
+  void play(int row=-1);
   void setOrder(unsigned char order, bool forced=false);
   void stop();
   void endIntroTune();


### PR DESCRIPTION
Changed behavior of FurnaceGUI::play - explicitly providing 0 will always play from row 0. Default argument of -1 will result in default behavior (play from row 0 unless currently stepping).

I updated the "Play/repeat from the beginning of this pattern" buttons to take advantage of this, but didn't touch any of the other buttons or actions, so they should still work the same as before.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
