### PR TITLE
combat vehicle auto framerate locking

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -7221,9 +7221,10 @@ bool FurnaceGUI::loop() {
     }
     drawTimeEnd=SDL_GetPerformanceCounter();
     swapTimeBegin=SDL_GetPerformanceCounter();
-    if (!settings.vsync || !rend->canVSync()) {
-      if (settings.frameRateLimit>0) {
-        unsigned int presentDelay=SDL_GetPerformanceFrequency()/settings.frameRateLimit;
+    framerateoverride=cvOpen?60:settings.frameRateLimit; // uh..
+    if (framerateoverride > 0|| !settings.vsync || !rend->canVSync()) {
+      if (framerateoverride>0) {
+        unsigned int presentDelay=SDL_GetPerformanceFrequency()/framerateoverride;
         if ((nextPresentTime-swapTimeBegin)<presentDelay) {
 #ifdef _WIN32
           unsigned int mDivider=SDL_GetPerformanceFrequency()/1000;

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -7222,7 +7222,7 @@ bool FurnaceGUI::loop() {
     drawTimeEnd=SDL_GetPerformanceCounter();
     swapTimeBegin=SDL_GetPerformanceCounter();
     framerateoverride=cvOpen?60:settings.frameRateLimit; // uh..
-    if (framerateoverride > 0|| !settings.vsync || !rend->canVSync()) {
+    if (framerateoverride > 0 || !settings.vsync || !rend->canVSync()) {
       if (framerateoverride>0) {
         unsigned int presentDelay=SDL_GetPerformanceFrequency()/framerateoverride;
         if ((nextPresentTime-swapTimeBegin)<presentDelay) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1669,6 +1669,7 @@ class FurnaceGUI {
   int wheelCalmDown;
   int shallDetectScale;
   int cpuCores;
+  int framerateoverride;
   float secondTimer;
   unsigned int userEvents;
   float mobileMenuPos, autoButtonSize, mobileEditAnim;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1669,7 +1669,7 @@ class FurnaceGUI {
   int wheelCalmDown;
   int shallDetectScale;
   int cpuCores;
-  int framerateoverride;
+  unsigned int framerateoverride;
   float secondTimer;
   unsigned int userEvents;
   float mobileMenuPos, autoButtonSize, mobileEditAnim;


### PR DESCRIPTION
*basically adding a framerate override to handle all of that and restores the original when exited*
tbf, it's kinda silly adding interpolation or whatever it is to accumulate for high framerates for combat vehicle itself.
