### PR TITLE
-txtout command line action

### DIFF
--- a/doc/8-advanced/command-line.md
+++ b/doc/8-advanced/command-line.md
@@ -78,9 +78,6 @@ the following parameters may be used:
 
 **export (other)**
 
-- `-zsmout path`: output Zsound Music data for Commander X16.
-  - you must provide a file, otherwise Furnace will quit.
-
 - `-cmdout path`: output command stream dump to `path`.
   - you must provide a file, otherwise Furnace will quit.
 

--- a/doc/8-advanced/command-line.md
+++ b/doc/8-advanced/command-line.md
@@ -84,6 +84,9 @@ the following parameters may be used:
 - `-cmdout path`: output command stream dump to `path`.
   - you must provide a file, otherwise Furnace will quit.
 
+- `-txtout path`: output text file export to `path`.
+  - you must provide a file, otherwise Furnace will quit.
+
 ## COMMAND LINE INTERFACE
 
 Furnace provides a command-line interface (CLI) player which may be activated through the `-console` option.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -862,7 +862,7 @@ int main(int argc, char** argv) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
         } else {
-          reportError(fmt::sprintf(_("could not open file! (%s)"),e.getLastError()));
+          reportError(fmt::sprintf(_("could not open file! (%s)"),cmdOutName.c_str()));
         }
         w->finish();
         delete w;
@@ -878,7 +878,7 @@ int main(int argc, char** argv) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
         } else {
-          reportError(fmt::sprintf(_("could not open file! (%s)"),e.getLastError()));
+          reportError(fmt::sprintf(_("could not open file! (%s)"),vgmOutName.c_str()));
         }
         w->finish();
         delete w;
@@ -900,7 +900,7 @@ int main(int argc, char** argv) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
         } else {
-          reportError(fmt::sprintf(_("could not open file! (%s)"),e.getLastError()));
+          reportError(fmt::sprintf(_("could not open file! (%s)"),txtOutName.c_str()));
         }
         w->finish();
         delete w;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -857,7 +857,7 @@ int main(int argc, char** argv) {
     if (cmdOutName!="") {
       SafeWriter* w=e.saveCommand();
       if (w!=NULL) {
-        FILE* f=fopen(cmdOutName.c_str(),"wb");
+        FILE* f=ps_fopen(cmdOutName.c_str(),"wb");
         if (f!=NULL) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
@@ -873,7 +873,7 @@ int main(int argc, char** argv) {
     if (vgmOutName!="") {
       SafeWriter* w=e.saveVGM(NULL,true,0x171,false,vgmOutDirect);
       if (w!=NULL) {
-        FILE* f=fopen(vgmOutName.c_str(),"wb");
+        FILE* f=ps_fopen(vgmOutName.c_str(),"wb");
         if (f!=NULL) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
@@ -895,7 +895,7 @@ int main(int argc, char** argv) {
       e.setConsoleMode(true);
       SafeWriter* w=e.saveText(false);
       if (w!=NULL) {
-        FILE* f=fopen(txtOutName.c_str(),"wb");
+        FILE* f=ps_fopen(txtOutName.c_str(),"wb");
         if (f!=NULL) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -862,7 +862,7 @@ int main(int argc, char** argv) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
         } else {
-          reportError(fmt::sprintf(_("could not open file! (%s)"),cmdOutName.c_str()));
+          reportError(fmt::sprintf(_("could not open file! (%s)"),strerror(errno)));
         }
         w->finish();
         delete w;
@@ -878,7 +878,7 @@ int main(int argc, char** argv) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
         } else {
-          reportError(fmt::sprintf(_("could not open file! (%s)"),vgmOutName.c_str()));
+          reportError(fmt::sprintf(_("could not open file! (%s)"),strerror(errno)));
         }
         w->finish();
         delete w;
@@ -900,7 +900,7 @@ int main(int argc, char** argv) {
           fwrite(w->getFinalBuf(),1,w->size(),f);
           fclose(f);
         } else {
-          reportError(fmt::sprintf(_("could not open file! (%s)"),txtOutName.c_str()));
+          reportError(fmt::sprintf(_("could not open file! (%s)"),strerror(errno)));
         }
         w->finish();
         delete w;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -725,14 +725,16 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  if (fileName.empty() && (benchMode || infoMode || outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="")) {
+  const bool outputMode = outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="";
+
+  if (fileName.empty() && (benchMode || infoMode || outputMode)) {
     logE("provide a file!");
     return 1;
   }
 
 #ifdef HAVE_GUI
-  if (e.preInit(consoleMode || benchMode || infoMode || outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="")) {
-    if (consoleMode || benchMode || infoMode || outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="") {
+  if (e.preInit(consoleMode || benchMode || infoMode || outputMode)) {
+    if (consoleMode || benchMode || infoMode || outputMode) {
       logW("engine wants safe mode, but Furnace GUI is not going to start.");
     } else {
       safeMode=true;
@@ -744,7 +746,7 @@ int main(int argc, char** argv) {
   }
 #endif
 
-  if (safeMode && (consoleMode || benchMode || infoMode || outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="")) {
+  if (safeMode && (consoleMode || benchMode || infoMode || outputMode)) {
     logE("you can't use safe mode and console/export mode together.");
     return 1;
   }
@@ -761,7 +763,7 @@ int main(int argc, char** argv) {
 #endif
 
 
-  if (!fileName.empty() && ((!e.getConfBool("tutIntroPlayed",TUT_INTRO_PLAYED)) || e.getConfInt("alwaysPlayIntro",0)!=3 || consoleMode || benchMode || infoMode || outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="")) {
+  if (!fileName.empty() && ((!e.getConfBool("tutIntroPlayed",TUT_INTRO_PLAYED)) || e.getConfInt("alwaysPlayIntro",0)!=3 || consoleMode || benchMode || infoMode || outputMode)) {
     logI("loading module...");
     FILE* f=ps_fopen(fileName.c_str(),"rb");
     if (f==NULL) {
@@ -853,7 +855,7 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  if (outName!="" || vgmOutName!="" || cmdOutName!="" || txtOutName!="") {
+  if (outputMode) {
     if (cmdOutName!="") {
       SafeWriter* w=e.saveCommand();
       if (w!=NULL) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -905,7 +905,7 @@ int main(int argc, char** argv) {
         w->finish();
         delete w;
       } else {
-        reportError(_("could not write txt!"));
+        reportError(_("could not write text!"));
       }
     }
     finishLogFile();


### PR DESCRIPTION
### Edited Summary
- Add `-txtout` command line option to export text file.
- Improve empty error message from command line output `fopen` failures (using `strerror(errno)`).
- Use `ps_fopen` instead of `fopen` for command line output, permitting unicode filenames on Windows.
- Consolidate boilerplate command line output text checks into a single boolean.
- Remove unimplemented `-zsmout` command from documentation.

### Original explanation

Add `-txtout` to allow command line export to text file. The desire for this feature is so that I can use it for export into a game engine's needed format, because the text export is easy to parse. I had written the text export feature for Famitracker years ago, and found it extremely useful in this way.

Included one other commit noting that `-cmdout` and `-vgmout` were giving an empty error if `fopen` fails, assuming it was intended to output the filename instead.

An aside note, I see `-zsmout` listed in the documentation, but it does not appear to exist in the code. Is this a mistake?