### PR TITLE
GUI: correct cursor position on song stop

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1259,7 +1259,7 @@ void FurnaceGUI::stop() {
   if (followPattern && wasPlaying) {
     nextScroll=-1.0f;
     nextAddScroll=0.0f;
-    cursor.y=oldRow;
+    e->getPlayPos(curOrder, cursor.y);
     if (selStart.xCoarse==selEnd.xCoarse && selStart.xFine==selEnd.xFine && selStart.y==selEnd.y && !selecting) {
       selStart=cursor;
       selEnd=cursor;


### PR DESCRIPTION
fix #2274 (song stopping on correct order but wrong row while "follow pattern" enabled)