### PR TITLE
ROM export command line

### DIFF
--- a/doc/8-advanced/command-line.md
+++ b/doc/8-advanced/command-line.md
@@ -81,6 +81,10 @@ the following parameters may be used:
 - `-cmdout path`: output command stream dump to `path`.
   - you must provide a file, otherwise Furnace will quit.
 
+- `-romout path`: output ROM file export to `path`.
+  - you must provide a file, otherwise Furnace will quit.
+  - there must be an available ROM export target for the system.
+
 - `-txtout path`: output text file export to `path`.
   - you must provide a file, otherwise Furnace will quit.
 

--- a/doc/8-advanced/command-line.md
+++ b/doc/8-advanced/command-line.md
@@ -85,6 +85,22 @@ the following parameters may be used:
   - you must provide a file, otherwise Furnace will quit.
   - there must be an available ROM export target for the system.
 
+- `-romconf key=value`: set a configuration parameter for `-romout`.
+  - you may use this multiple times to set multiple parameters.
+  - Amiga Validation
+    - no parameters.
+  - Commander X16 ZSM
+    - `zsmrate`: tick rate (Hz), default: `60`
+    - `loop`: loop song, default: `true`
+    - `optimize`: optimize size, default: `true`
+  - Atari 2600 (TIunA)
+    - `baseLabel`: base song label name, default: `song`
+    - `firstBankSize`: max size in first bank, default: `3072`
+    - `otherBankSize`: max size in other banks, default: `4048`
+    - `sysToExport`: TIA chip index, default: `-1` (find first)
+  - Atari 8-bit SAP-R
+    - no parameters.
+
 - `-txtout path`: output text file export to `path`.
   - you must provide a file, otherwise Furnace will quit.
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -908,6 +908,8 @@ class DivEngine {
 
     // get ROM export definition
     const DivROMExportDef* getROMExportDef(DivROMExportOptions opt);
+    // check whether ROM export option is viable for current song
+    bool isROMExportViable(DivROMExportOptions opt);
 
     // convert sample rate format
     int fileToDivRate(int frate);

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -769,60 +769,13 @@ void FurnaceGUI::autoDetectSystem() {
 }
 
 void FurnaceGUI::updateROMExportAvail() {
-  unsigned char sysReqCount[DIV_SYSTEM_MAX];
-  unsigned char defReqCount[DIV_SYSTEM_MAX];
-
-  memset(sysReqCount,0,DIV_SYSTEM_MAX);
-  for (int i=0; i<e->song.systemLen; i++) {
-    sysReqCount[e->song.system[i]]++;
-  }
-
   memset(romExportAvail,0,sizeof(bool)*DIV_ROM_MAX);
   romExportExists=false;
 
   for (int i=0; i<DIV_ROM_MAX; i++) {
-    const DivROMExportDef* newDef=e->getROMExportDef((DivROMExportOptions)i);
-    if (newDef!=NULL) {
-      // check for viability
-      bool viable=true;
-
-      memset(defReqCount,0,DIV_SYSTEM_MAX);
-      for (DivSystem j: newDef->requisites) {
-        defReqCount[j]++;
-      }
-
-      switch (newDef->requisitePolicy) {
-        case DIV_REQPOL_EXACT:
-          for (int j=0; j<DIV_SYSTEM_MAX; j++) {
-            if (defReqCount[j]!=sysReqCount[j]) {
-              viable=false;
-              break;
-            }
-          }
-          break;
-        case DIV_REQPOL_ANY:
-          for (int j=0; j<DIV_SYSTEM_MAX; j++) {
-            if (defReqCount[j]>sysReqCount[j]) {
-              viable=false;
-              break;
-            }
-          }
-          break;
-        case DIV_REQPOL_LAX:
-          viable=false;
-          for (DivSystem j: newDef->requisites) {
-            if (defReqCount[j]<=sysReqCount[j]) {
-              viable=true;
-              break;
-            }
-          }
-          break;
-      }
-      
-      if (viable) {
-        romExportAvail[i]=true;
-        romExportExists=true;
-      }
+    if (e->isROMExportViable((DivROMExportOptions)i)) {
+      romExportAvail[i]=true;
+      romExportExists=true;
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <string.h>
 #include "pch.h"
 #ifdef HAVE_SDL2
 #include "SDL_events.h"
@@ -921,13 +920,17 @@ int main(int argc, char** argv) {
       e.setConsoleMode(true);
       // select ROM target type
       DivROMExportOptions romTarget = DIV_ROM_ABSTRACT;
+      String lowerCase=romOutName;
+      for (char& i: lowerCase) {
+        if (i>='A' && i<='Z') i+='a'-'A';
+      }
       for (int i=0; i<DIV_ROM_MAX; i++) {
         DivROMExportOptions opt = (DivROMExportOptions)i;
         if (e.isROMExportViable(opt)) {
           const DivROMExportDef* newDef=e.getROMExportDef((DivROMExportOptions)i);
           if (newDef->fileExt &&
-              romOutName.length()>=strlen(newDef->fileExt) &&
-              !stricmp(newDef->fileExt,romOutName.c_str()+(romOutName.length()-strlen(newDef->fileExt)))) {
+              lowerCase.length()>=strlen(newDef->fileExt) &&
+              lowerCase.substr(lowerCase.length()-strlen(newDef->fileExt))==newDef->fileExt) {
             romTarget = opt;
             break; // extension matched, stop searching
           }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,7 +481,7 @@ void initParams() {
   params.push_back(TAParam("O","vgmout",true,pVGMOut,"<filename>","output .vgm data"));
   params.push_back(TAParam("D","direct",false,pDirect,"","set VGM export direct stream mode"));
   params.push_back(TAParam("C","cmdout",true,pCmdOut,"<filename>","output command stream"));
-  params.push_back(TAParam("r","romout",true,pROMOut,"<filename>","export ROM file"));
+  params.push_back(TAParam("r","romout",true,pROMOut,"<filename|path>","export ROM file, or path for multi-file export"));
   params.push_back(TAParam("R","romconf",true,pROMConf,"<key>=<value>","set configuration parameter for ROM export"));
   params.push_back(TAParam("t","txtout",true,pTxtOut,"<filename>","export as text file"));
   params.push_back(TAParam("L","loglevel",true,pLogLevel,"debug|info|warning|error","set the log level (info by default)"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 #include "pch.h"
 #ifdef HAVE_SDL2
 #include "SDL_events.h"


### PR DESCRIPTION
Adds two command line features:
* `-romout` command line for ROM export
* `-romconf` command line for `-romout` configuration paramters

I had investigated this a little with #2288 but afterward I realized it maybe wasn't as complex as it looked.

I don't personally have a use/need for this feature, but perhaps someone else would appreciate it, since it seemed `-zsmout` was wanted previously. One thing I could suggest is that it might be useful for creating unit tests of the ROM exports.

The `-romconf` allows setting the export parameters as needed, though it is very simply just adding key/value pairs to the `DivConfig` used by the exporters. This is easy to implement, but creates the problem of having to document the possible values, which I did for the existing exporters. The existing parameter names seem a little bit "internal", but they are quite functional as-is.

I was thinking it would be more ideal if the ROM config parameters were described in `romExportDefs`, maybe with a vector of String triples (key string, default value string, description). That would avoid the need to maintain a list in the document, since we could provide a way to learn this information in-program instead. It might also avoid the problem of the documentation getting out of sync with the code.

Anyway, not sure if this feature is wanted at this time, but it seemed to require only a little bit of code to accomplish, so I thought I should offer it as a suggestion.