### PR TITLE
YM2610: adjust Delta-N value computation for ADPCM-B

### DIFF
--- a/src/engine/platform/ym2608.cpp
+++ b/src/engine/platform/ym2608.cpp
@@ -289,7 +289,7 @@ double DivPlatformYM2608::NOTE_OPNB(int ch, int note) {
 
 double DivPlatformYM2608::NOTE_ADPCMB(int note) {
   if (chan[15+isCSM].sample>=0 && chan[15+isCSM].sample<parent->song.sampleLen) {
-    double off=65535.0*(double)(parent->getSample(chan[15+isCSM].sample)->centerRate)/8363.0;
+    double off=65535.0*(double)(parent->getSample(chan[15+isCSM].sample)->centerRate)/8372.0;
     return parent->calcBaseFreq((double)chipClock/144,off,note,false);
   }
   return 0;
@@ -982,7 +982,7 @@ void DivPlatformYM2608::tick(bool sysTick) {
   if (chan[(15+isCSM)].freqChanged || chan[(15+isCSM)].keyOn || chan[(15+isCSM)].keyOff) {
     if (chan[(15+isCSM)].furnacePCM) {
       if (chan[(15+isCSM)].sample>=0 && chan[(15+isCSM)].sample<parent->song.sampleLen) {
-        double off=65535.0*(double)(parent->getSample(chan[(15+isCSM)].sample)->centerRate)/8363.0;
+        double off=65535.0*(double)(parent->getSample(chan[(15+isCSM)].sample)->centerRate)/8372.0;
         chan[(15+isCSM)].freq=parent->calcFreq(chan[(15+isCSM)].baseFreq,chan[(15+isCSM)].pitch,chan[(15+isCSM)].fixedArp?chan[(15+isCSM)].baseNoteOverride:chan[(15+isCSM)].arpOff,chan[(15+isCSM)].fixedArp,false,4,chan[(15+isCSM)].pitch2,(double)chipClock/144,off);
       } else {
         chan[(15+isCSM)].freq=0;
@@ -1166,7 +1166,7 @@ int DivPlatformYM2608::dispatch(DivCommand c) {
             immWrite(0x104,(end>>5)&0xff);
             immWrite(0x105,(end>>13)&0xff);
             immWrite(0x101,(isMuted[c.chan]?0:(chan[c.chan].pan<<6))|1);
-            int freq=(65536.0*(double)s->rate)/((double)chipClock/144.0);
+            int freq=(65535.0*(double)s->rate)/((double)chipClock/144.0);
             immWrite(0x109,freq&0xff);
             immWrite(0x10a,(freq>>8)&0xff);
             immWrite(0x10b,chan[c.chan].outVol);

--- a/src/engine/platform/ym2610.cpp
+++ b/src/engine/platform/ym2610.cpp
@@ -912,7 +912,7 @@ void DivPlatformYM2610::tick(bool sysTick) {
   if (chan[adpcmBChanOffs].freqChanged || chan[adpcmBChanOffs].keyOn || chan[adpcmBChanOffs].keyOff) {
     if (chan[adpcmBChanOffs].furnacePCM) {
       if (chan[adpcmBChanOffs].sample>=0 && chan[adpcmBChanOffs].sample<parent->song.sampleLen) {
-        double off=65535.0*(double)(parent->getSample(chan[adpcmBChanOffs].sample)->centerRate)/8363.0;
+        double off=65535.0*(double)(parent->getSample(chan[adpcmBChanOffs].sample)->centerRate)/8372.0;
         chan[adpcmBChanOffs].freq=parent->calcFreq(chan[adpcmBChanOffs].baseFreq,chan[adpcmBChanOffs].pitch,chan[adpcmBChanOffs].fixedArp?chan[adpcmBChanOffs].baseNoteOverride:chan[adpcmBChanOffs].arpOff,chan[adpcmBChanOffs].fixedArp,false,4,chan[adpcmBChanOffs].pitch2,(double)chipClock/144,off);
       } else {
         chan[adpcmBChanOffs].freq=0;
@@ -1090,7 +1090,7 @@ int DivPlatformYM2610::dispatch(DivCommand c) {
             immWrite(0x14,(end>>8)&0xff);
             immWrite(0x15,end>>16);
             immWrite(0x11,isMuted[c.chan]?0:(chan[c.chan].pan<<6));
-            int freq=(65536.0*(double)s->rate)/((double)chipClock/144.0);
+            int freq=(65535.0*(double)s->rate)/((double)chipClock/144.0);
             immWrite(0x19,freq&0xff);
             immWrite(0x1a,(freq>>8)&0xff);
             immWrite(0x1b,chan[c.chan].outVol);

--- a/src/engine/platform/ym2610b.cpp
+++ b/src/engine/platform/ym2610b.cpp
@@ -980,7 +980,7 @@ void DivPlatformYM2610B::tick(bool sysTick) {
   if (chan[adpcmBChanOffs].freqChanged || chan[adpcmBChanOffs].keyOn || chan[adpcmBChanOffs].keyOff) {
     if (chan[adpcmBChanOffs].furnacePCM) {
       if (chan[adpcmBChanOffs].sample>=0 && chan[adpcmBChanOffs].sample<parent->song.sampleLen) {
-        double off=65535.0*(double)(parent->getSample(chan[adpcmBChanOffs].sample)->centerRate)/8363.0;
+        double off=65535.0*(double)(parent->getSample(chan[adpcmBChanOffs].sample)->centerRate)/8372.0;
         chan[adpcmBChanOffs].freq=parent->calcFreq(chan[adpcmBChanOffs].baseFreq,chan[adpcmBChanOffs].pitch,chan[adpcmBChanOffs].fixedArp?chan[adpcmBChanOffs].baseNoteOverride:chan[adpcmBChanOffs].arpOff,chan[adpcmBChanOffs].fixedArp,false,4,chan[adpcmBChanOffs].pitch2,(double)chipClock/144,off);
       } else {
         chan[adpcmBChanOffs].freq=0;
@@ -1158,7 +1158,7 @@ int DivPlatformYM2610B::dispatch(DivCommand c) {
             immWrite(0x14,(end>>8)&0xff);
             immWrite(0x15,end>>16);
             immWrite(0x11,isMuted[c.chan]?0:(chan[c.chan].pan<<6));
-            int freq=(65536.0*(double)s->rate)/((double)chipClock/144.0);
+            int freq=(65535.0*(double)s->rate)/((double)chipClock/144.0);
             immWrite(0x19,freq&0xff);
             immWrite(0x1a,(freq>>8)&0xff);
             immWrite(0x1b,chan[c.chan].outVol);

--- a/src/engine/platform/ym2610shared.h
+++ b/src/engine/platform/ym2610shared.h
@@ -101,7 +101,7 @@ class DivPlatformYM2610Base: public DivPlatformOPN {
     }
     double NOTE_ADPCMB(int note) {
       if (chan[adpcmBChanOffs].sample>=0 && chan[adpcmBChanOffs].sample<parent->song.sampleLen) {
-        double off=65535.0*(double)(parent->getSample(chan[adpcmBChanOffs].sample)->centerRate)/8363.0;
+        double off=65535.0*(double)(parent->getSample(chan[adpcmBChanOffs].sample)->centerRate)/8372.0;
         return parent->calcBaseFreq((double)chipClock/144,off,note,false);
       }
       return 0;


### PR DESCRIPTION
Update the offset factor used to compute ADPCM-B note frequency so that the C-4 maps to the sample rate defined in the instrument.

Fix a factor used for Delta-N conversion as per YM2610 specs.

