### PR TITLE
Moving sample filter "Sweep" checkbox.

### DIFF
--- a/doc/6-sample/README.md
+++ b/doc/6-sample/README.md
@@ -151,6 +151,8 @@ in there, you can modify certain data pertaining to your sample, such as the:
 - **Signed/unsigned exchange**: reinterprets selection data as being of the opposite sign.
   - if a sample sounds fine elsewhere but is distorted on import, it may have been interpreted as signed when it should be unsigned, or vice versa; this will correct that.
 - **Apply filter**: filters the selection. pops up a dialog box:
+  - **Frequency**: filter cutoff frequency.
+  - **Sweep (2 frequencies)**: changes "Frequency" to separate "From" and "To" sliders.
   - **From**: filter cutoff frequency at start of selection.
   - **To**: filter cutoff frequency at end of selection.
   - **Resonance**: emphasizes frequencies around filter cutoff.

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -8731,7 +8731,7 @@ FurnaceGUI::FurnaceGUI():
   sampleFilterRes(0.25f),
   sampleFilterCutStart(16000.0f),
   sampleFilterCutEnd(100.0f),
-  sampleFilterSweep(true),
+  sampleFilterSweep(false),
   sampleFilterFirstFrame(true),
   sampleCrossFadeLoopLength(0),
   sampleCrossFadeLoopLaw(50),

--- a/src/gui/sampleEdit.cpp
+++ b/src/gui/sampleEdit.cpp
@@ -1196,7 +1196,6 @@ void FurnaceGUI::drawSampleEdit() {
         float resP=sampleFilterRes*100.0f;
         ImGui::Text(_("Cutoff:"));
 
-        ImGui::Checkbox(_("Sweep (2 frequencies)"),&sampleFilterSweep);
         if (sampleFilterSweep) {
           if (ImGui::SliderFloat(_("From"),&sampleFilterCutStart,minCutoff,maxCutoff,"%.0f Hz")) {
             if (sampleFilterCutStart<minCutoff) sampleFilterCutStart=minCutoff;
@@ -1212,6 +1211,7 @@ void FurnaceGUI::drawSampleEdit() {
             if (sampleFilterCutStart>maxCutoff) sampleFilterCutStart=maxCutoff;
           }
         }
+        ImGui::Checkbox(_("Sweep (2 frequencies)"),&sampleFilterSweep);
 
         ImGui::Separator();
         if (ImGui::SliderFloat(_("Resonance"),&resP,0.0f,99.0f,"%.1f%%")) {


### PR DESCRIPTION
It just makes more sense to be after the single Frequency slider, where the second slider will appear.

Also, setting the default Sweep to off.

Also also, updating the corresponding documentation.