### PR TITLE
Add placeholder name with extension to save dialog

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1767,6 +1767,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
   bool hasOpened=false;
 
   String shortName;
+  String saveNameTemplate=String(DIR_SEPARATOR_STR)+_("example");
   size_t shortNamePos=curFileName.rfind(DIR_SEPARATOR);
   if (shortNamePos!=String::npos && (shortNamePos+1)<curFileName.size()) {
     shortName=curFileName.substr(shortNamePos+1);
@@ -1805,7 +1806,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save File"),
         {_("Furnace song"), "*.fur"},
-        workingDirSong,
+        workingDirSong+saveNameTemplate+".fur",
         dpiScale
       );
       break;
@@ -1814,7 +1815,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export DMF"),
         {_("DefleMask 1.1.3 module"), "*.dmf"},
-        workingDirSong,
+        workingDirSong+saveNameTemplate+".dmf",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -1824,7 +1825,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export DMF"),
         {_("DefleMask 1.0/legacy module"), "*.dmf"},
-        workingDirSong,
+        workingDirSong+saveNameTemplate+".dmf",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -1892,7 +1893,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Instrument"),
         {_("Furnace instrument"), "*.fui"},
-        workingDirIns,
+        workingDirIns+saveNameTemplate+".fui",
         dpiScale,
         (settings.autoFillSave)?e->getIns(curIns)->name:""
       );
@@ -1902,7 +1903,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Instrument"),
         {_("DefleMask preset"), "*.dmp"},
-        workingDirIns,
+        workingDirIns+saveNameTemplate+".dmp",
         dpiScale,
         (settings.autoFillSave)?e->getIns(curIns)->name:""
       );
@@ -1933,7 +1934,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Wavetable"),
         {_("Furnace wavetable"), ".fuw"},
-        workingDirWave,
+        workingDirWave+saveNameTemplate+".fuw",
         dpiScale
       );
       break;
@@ -1942,7 +1943,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Wavetable"),
         {_("DefleMask wavetable"), ".dmw"},
-        workingDirWave,
+        workingDirWave+saveNameTemplate+".dmw",
         dpiScale
       );
       break;
@@ -1951,7 +1952,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Wavetable"),
         {_("raw data"), ".raw"},
-        workingDirWave,
+        workingDirWave+saveNameTemplate+".raw",
         dpiScale
       );
       break;
@@ -1990,7 +1991,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Sample"),
         {_("Wave file"), "*.wav"},
-        workingDirSample,
+        workingDirSample+saveNameTemplate+".wav",
         dpiScale,
         (settings.autoFillSave)?e->getSample(curSample)->name:""
       );
@@ -2000,7 +2001,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Save Raw Sample"),
         {_("all files"), "*"},
-        workingDirSample,
+        workingDirSample+saveNameTemplate,
         dpiScale,
         (settings.autoFillSave)?e->getSample(curSample)->name:""
       );
@@ -2018,7 +2019,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Audio"),
         {_("Wave file"), "*.wav"},
-        workingDirAudioExport,
+        workingDirAudioExport+saveNameTemplate+".wav",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -2028,7 +2029,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Audio"),
         {_("Wave file"), "*.wav"},
-        workingDirAudioExport,
+        workingDirAudioExport+saveNameTemplate+".wav",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -2038,7 +2039,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Audio"),
         {_("Wave file"), "*.wav"},
-        workingDirAudioExport,
+        workingDirAudioExport+saveNameTemplate+".wav",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -2048,7 +2049,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export VGM"),
         {_("VGM file"), "*.vgm"},
-        workingDirVGMExport,
+        workingDirVGMExport+saveNameTemplate+".vgm",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -2058,7 +2059,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Command Stream"),
         {_("text file"), "*.txt"},
-        workingDirROMExport,
+        workingDirROMExport+saveNameTemplate+".txt",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -2068,7 +2069,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Command Stream"),
         {_("binary file"), "*.bin"},
-        workingDirROMExport,
+        workingDirROMExport+saveNameTemplate+".bin",
         dpiScale,
         (settings.autoFillSave)?shortName:""
       );
@@ -2085,7 +2086,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
         hasOpened=fileDialog->openSave(
           _("Export ROM"),
           {romFilterName, "*"+romFilterExt},
-          workingDirROMExport,
+          workingDirROMExport+saveNameTemplate+romFilterExt,
           dpiScale,
           (settings.autoFillSave)?shortName:""
         );
@@ -2169,7 +2170,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Colors"),
         {_("configuration files"), "*.cfgc"},
-        workingDirColors,
+        workingDirColors+saveNameTemplate+".cfgc",
         dpiScale
       );
       break;
@@ -2178,7 +2179,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Keybinds"),
         {_("configuration files"), "*.cfgk"},
-        workingDirKeybinds,
+        workingDirKeybinds+saveNameTemplate+".cfgk",
         dpiScale
       );
       break;
@@ -2187,7 +2188,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Layout"),
         {_(".ini files"), "*.ini"},
-        workingDirLayout,
+        workingDirLayout+saveNameTemplate+".ini",
         dpiScale
       );
       break;
@@ -2196,7 +2197,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export User Presets"),
         {_("configuration files"), "*.cfgu"},
-        workingDirConfig,
+        workingDirConfig+saveNameTemplate+".cfgu",
         dpiScale
       );
       break;
@@ -2205,7 +2206,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
       hasOpened=fileDialog->openSave(
         _("Export Settings"),
         {_("configuration files"), "*.cfg"},
-        workingDirConfig,
+        workingDirConfig+saveNameTemplate+".cfg",
         dpiScale
       );
       break;
@@ -2274,7 +2275,7 @@ void FurnaceGUI::openFileDialog(FurnaceGUIFileDialogs type) {
         _("Save Test"),
         {_("Furnace song"), "*.fur",
          _("DefleMask module"), "*.dmf"},
-        workingDirTest,
+        workingDirTest+saveNameTemplate+".fur",
         dpiScale
       );
       break;


### PR DESCRIPTION
This means users on gnome desktop don't have to add the extension manually.

The dialog opens with the placeholder filename selected ready for the user to replace it:
![Screenshot From 2025-03-30 22-49-34](https://github.com/user-attachments/assets/5898ddab-1554-453d-951b-7f5437b6230a)