### PR TITLE
Improve Virtual Boy emulator

### DIFF
--- a/src/engine/platform/sound/vsu.h
+++ b/src/engine/platform/sound/vsu.h
@@ -74,7 +74,8 @@ class VSU
  //
  //
  int EffFreq[6];
- int Envelope[6];
+ int EnvelopeValue[6];
+ int EnvelopeReload[6];
 
  int WavePos[6];
  int ModWavePos;
@@ -90,6 +91,8 @@ class VSU
  int IntervalClockDivider[6];
  int EnvelopeClockDivider[6];
  int SweepModClockDivider;
+
+ int EnvelopeModMask[6];
 
  int NoiseLatcherClockDivider;
  unsigned int NoiseLatcher;

--- a/src/engine/platform/sound/vsu.h
+++ b/src/engine/platform/sound/vsu.h
@@ -93,6 +93,8 @@ class VSU
  int SweepModClockDivider;
 
  int EnvelopeModMask[6];
+ int ModState;
+ int ModLock;
 
  int NoiseLatcherClockDivider;
  unsigned int NoiseLatcher;


### PR DESCRIPTION
This PR updates the built-in Mednafen core with additional hardware bugs, as mentioned in #2442. It does not update Furnace's effect code to take these bugs into account. Key points worth keeping in mind for the exposed hardware effects:
* Envelopes will need to be reset by a write to SxINT somewhere between when one finishes and when the next one starts. Try making a module where an envelope goes all the way up or down, then try starting another one - it won't work.
* When an upward sweep goes beyond the maximum frequency, the channel cuts. It will need to be reactivated by a write to SxINT.
* When one round of modulation has happened, regardless of whether repeating is on, both non-repeating modulation *and* sweeping are blocked until the next write to SxINT.