### PR TITLE
Run SDL_Quit before exiting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1094,5 +1094,10 @@ int main(int argc, char** argv) {
   }
 #endif
   e.everythingOK();
+
+#ifdef HAVE_SDL2
+  SDL_Quit();
+#endif
+
   return 0;
 }


### PR DESCRIPTION
While running using sdl2-compat and the environment variable `SDL2COMPAT_DEBUG_LOGGING=1`. furnace prints the following on exit.

```
sdl2-compat: Leaking SDL3 library reference due to missing call to SDL_Quit()
```

I'm sure it's harmless.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
