### PR TITLE
Instrument reader 4-op hotfix

### DIFF
--- a/src/engine/cmdStreamOps.cpp
+++ b/src/engine/cmdStreamOps.cpp
@@ -21,6 +21,7 @@
 #include "../ta-log.h"
 #include <stack>
 #include <unordered_map>
+#include <cassert>
 
 int DivCS::getCmdLength(unsigned char ext) {
   switch (ext) {

--- a/src/engine/cmdStreamOps.cpp
+++ b/src/engine/cmdStreamOps.cpp
@@ -21,7 +21,7 @@
 #include "../ta-log.h"
 #include <stack>
 #include <unordered_map>
-#include <cassert>
+#include <assert.h>
 
 int DivCS::getCmdLength(unsigned char ext) {
   switch (ext) {

--- a/src/engine/instrument.cpp
+++ b/src/engine/instrument.cpp
@@ -1747,6 +1747,10 @@ void DivInstrument::readFeatureFM(SafeReader& reader, short version) {
   next=reader.readC();
   fm.ams2=(next>>6)&3;
   fm.ops=(next&32)?4:2;
+  if (opCount>fm.ops) {
+    logD("Initial op count > packed value");
+    fm.ops = opCount;
+  }
   fm.opllPreset=next&31;
 
   if (version>=224) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include "pch.h"
 #ifdef HAVE_SDL2
+#include "SDL.h"
 #include "SDL_events.h"
 #endif
 #include "ta-log.h"


### PR DESCRIPTION
engine/instrument.cpp:
  If the instrument's op count is higher than the value implied by the single bit present in the AM2 byte, it is accepted as a source of truth. This fixes the text output not containing all operator data.

engine/cmdStreamOps.cpp:
  <cassert> is included for the sake of the classic C-style asserts employed in the file.

main.cpp:
  SDL2's SDL_Quit() is declared by SDL.h, but only SDL_event.h was included prior.