### PR TITLE
[Android] Update Gradle version for compatibility with latest Java releases, and fix deprecation warnings

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,12 +9,12 @@ else {
 
 android {
     if (buildAsApplication) {
-        namespace "org.tildearrow.furnace"
+        namespace = "org.tildearrow.furnace"
     }
-    compileSdkVersion 26
+    compileSdkVersion 35
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 35
         versionCode 228
         versionName "0.6.8.1"
         externalNativeBuild {
@@ -30,6 +30,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     applicationVariants.all { variant ->
         tasks["merge${variant.name.capitalize()}Assets"]
@@ -47,7 +51,7 @@ android {
        
     }
     lint {
-        abortOnError false
+        abortOnError = false
     }
 
     if (buildAsLibrary) {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.tildearrow.furnace"
     android:versionCode="228"
     android:versionName="0.6.8.1"
     android:installLocation="auto">

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.12.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 11 18:20:34 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->

Moved the target SDK version to 35, as per Google Play policies and especially avoiding the "this app was built for an older version of Android" warning. Targeting for Java 8 is deprecated on releases 24 and up. Also fixed other Gradle-related deprecation warnings.