### PR TITLE
Add documentation for effect 16xy for FDS

### DIFF
--- a/doc/7-systems/fds.md
+++ b/doc/7-systems/fds.md
@@ -24,6 +24,11 @@ it also offers an additional 6-bit, 64-byte wavetable sound channel with (somewh
     - 6: -2
     - 7: -1
   - **do not use this effect.** it only exists for compatibility reasons
+- `16xy`: **enable automatic modulation speed mode.**
+  - in this mode the modulation speed is set to the channel's notes, multiplied by a fraction.
+  - `x` is the numerator.
+  - `y` is the denominator.
+  - if `x` or `y` are 0 this will disable automatic modulation speed mode.
 
 ## info
 


### PR DESCRIPTION
Automatic modulation speed, using effect 16xy, was not documented for the Famicom Disk System. This commit adds documentation. It was adapted from pre-existing documentation for envelope speeds that says roughly the same thing.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
