### PR TITLE
Import improvements for S3M, XM, MOD and IT

### DIFF
--- a/src/engine/fileOps/it.cpp
+++ b/src/engine/fileOps/it.cpp
@@ -1516,6 +1516,26 @@ bool DivEngine::loadIT(unsigned char* file, size_t len) {
               break;
             case 'S': // special...
               switch (effectVal[chan]>>4) {
+                case 0x3: // vibrato waveform
+                  switch (effectVal[chan]&3) {
+                    case 0x0: // sine
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x00;
+                      break;
+                    case 0x1: // ramp down
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x05;
+                      break;
+                    case 0x2: // square
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x06;
+                      break;
+                    case 0x3: // random
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x07;
+                      break;
+                  }
+                  break;
                 case 0x8: // panning
                   p->data[readRow][effectCol[chan]++]=0x80;
                   p->data[readRow][effectCol[chan]++]=(effectVal[chan]&15)<<4;

--- a/src/engine/fileOps/it.cpp
+++ b/src/engine/fileOps/it.cpp
@@ -1536,9 +1536,45 @@ bool DivEngine::loadIT(unsigned char* file, size_t len) {
                       break;
                   }
                   break;
+                case 0x7:
+                  switch (effectVal[chan]&15) {
+                    case 0x7: // volume envelope off
+                      p->data[readRow][effectCol[chan]++]=0xf5;
+                      p->data[readRow][effectCol[chan]++]=0x00;
+                      break;
+                    case 0x8: // volume envelope on
+                      p->data[readRow][effectCol[chan]++]=0xf6;
+                      p->data[readRow][effectCol[chan]++]=0x00;
+                      break;
+                    case 0x9: // panning envelope off
+                      p->data[readRow][effectCol[chan]++]=0xf5;
+                      p->data[readRow][effectCol[chan]++]=0x0c;
+                      p->data[readRow][effectCol[chan]++]=0xf5;
+                      p->data[readRow][effectCol[chan]++]=0x0d;
+                      break;
+                    case 0xa: // panning envelope on
+                      p->data[readRow][effectCol[chan]++]=0xf6;
+                      p->data[readRow][effectCol[chan]++]=0x0c;
+                      p->data[readRow][effectCol[chan]++]=0xf6;
+                      p->data[readRow][effectCol[chan]++]=0x0d;
+                      break;
+                    case 0xb: // pitch envelope off
+                      p->data[readRow][effectCol[chan]++]=0xf5;
+                      p->data[readRow][effectCol[chan]++]=0x04;
+                      break;
+                    case 0xc: //pitch envelope on
+                      p->data[readRow][effectCol[chan]++]=0xf6;
+                      p->data[readRow][effectCol[chan]++]=0x04;
+                      break;
+                  }
+                  break;
                 case 0x8: // panning
                   p->data[readRow][effectCol[chan]++]=0x80;
                   p->data[readRow][effectCol[chan]++]=(effectVal[chan]&15)<<4;
+                  break;
+                case 0xa: // offset (high nibble)
+                  p->data[readRow][effectCol[chan]++]=0x92;
+                  p->data[readRow][effectCol[chan]++]=effectVal[chan]&15;
                   break;
                 case 0xc: // note cut
                   p->data[readRow][effectCol[chan]++]=0xec;

--- a/src/engine/fileOps/it.cpp
+++ b/src/engine/fileOps/it.cpp
@@ -1516,15 +1516,15 @@ bool DivEngine::loadIT(unsigned char* file, size_t len) {
               break;
             case 'S': // special...
               switch (effectVal[chan]>>4) {
-                case 0x8:
+                case 0x8: // panning
                   p->data[readRow][effectCol[chan]++]=0x80;
                   p->data[readRow][effectCol[chan]++]=(effectVal[chan]&15)<<4;
                   break;
-                case 0xc:
+                case 0xc: // note cut
                   p->data[readRow][effectCol[chan]++]=0xec;
                   p->data[readRow][effectCol[chan]++]=effectVal[chan]&15;
                   break;
-                case 0xd:
+                case 0xd: // note delay
                   p->data[readRow][effectCol[chan]++]=0xed;
                   p->data[readRow][effectCol[chan]++]=effectVal[chan]&15;
                   break;

--- a/src/engine/fileOps/mod.cpp
+++ b/src/engine/fileOps/mod.cpp
@@ -356,6 +356,20 @@ bool DivEngine::loadMod(unsigned char* file, size_t len) {
                 case 2: // single note slide down
                   writeFxCol(fxTyp-1+0xf1,fxVal);
                   break;
+                case 0x3: // vibrato waveform
+                  switch (fxVal&3) {
+                    case 0x0: // sine
+                      writeFxCol(0xe3,0x00);
+                      break;
+                    case 0x1: // ramp down
+                      writeFxCol(0xe3,0x05);
+                      break;
+                    case 0x2: // square
+                    case 0x3: 
+                      writeFxCol(0xe3,0x06);
+                      break;
+                  }
+                break;
                 case 9: // retrigger
                   writeFxCol(0x0c,fxVal);
                   break;

--- a/src/engine/fileOps/s3m.cpp
+++ b/src/engine/fileOps/s3m.cpp
@@ -1101,15 +1101,15 @@ bool DivEngine::loadS3M(unsigned char* file, size_t len) {
               break;
             case 'S': // special...
               switch (effectVal>>4) {
-                case 0x8:
+                case 0x8: // panning
                   p->data[readRow][effectCol[chan]++]=0x80;
                   p->data[readRow][effectCol[chan]++]=(effectVal&15)<<4;
                   break;
-                case 0xc:
+                case 0xc: // note cut
                   p->data[readRow][effectCol[chan]++]=0xec;
                   p->data[readRow][effectCol[chan]++]=effectVal&15;
                   break;
-                case 0xd:
+                case 0xd: // note delay
                   p->data[readRow][effectCol[chan]++]=0xed;
                   p->data[readRow][effectCol[chan]++]=effectVal&15;
                   break;

--- a/src/engine/fileOps/s3m.cpp
+++ b/src/engine/fileOps/s3m.cpp
@@ -1101,6 +1101,26 @@ bool DivEngine::loadS3M(unsigned char* file, size_t len) {
               break;
             case 'S': // special...
               switch (effectVal>>4) {
+                case 0x3: // vibrato waveform
+                  switch (effectVal&3) {
+                    case 0x0: // sine
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x00;
+                      break;
+                    case 0x1: // ramp down
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x05;
+                      break;
+                    case 0x2: // square
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x06;
+                      break;
+                    case 0x3: // random
+                      p->data[readRow][effectCol[chan]++]=0xe3;
+                      p->data[readRow][effectCol[chan]++]=0x07;
+                      break;
+                  }
+                  break;
                 case 0x8: // panning
                   p->data[readRow][effectCol[chan]++]=0x80;
                   p->data[readRow][effectCol[chan]++]=(effectVal&15)<<4;

--- a/src/engine/fileOps/xm.cpp
+++ b/src/engine/fileOps/xm.cpp
@@ -1147,11 +1147,11 @@ bool DivEngine::loadXM(unsigned char* file, size_t len) {
               case 0xe: // special...
                 // TODO: implement the rest
                 switch (effectVal>>4) {
-                  case 0x5:
+                  case 0x5: // fine tune
                     p->data[j][effectCol[k]++]=0xe5;
                     p->data[j][effectCol[k]++]=(effectVal&15)<<4;
                     break;
-                  case 0x9:
+                  case 0x9: // retrigger
                     p->data[j][effectCol[k]++]=0x0c;
                     p->data[j][effectCol[k]++]=(effectVal&15);
                     break;
@@ -1171,11 +1171,11 @@ bool DivEngine::loadXM(unsigned char* file, size_t len) {
                     }
                     volSliding[k]=true;
                     break;
-                  case 0xc:
+                  case 0xc: // note cut
                     p->data[j][effectCol[k]++]=0xdc;
                     p->data[j][effectCol[k]++]=MAX(1,effectVal&15);
                     break;
-                  case 0xd:
+                  case 0xd: // note delay
                     p->data[j][effectCol[k]++]=0xed;
                     p->data[j][effectCol[k]++]=MAX(1,effectVal&15);
                     break;

--- a/src/engine/fileOps/xm.cpp
+++ b/src/engine/fileOps/xm.cpp
@@ -1147,6 +1147,23 @@ bool DivEngine::loadXM(unsigned char* file, size_t len) {
               case 0xe: // special...
                 // TODO: implement the rest
                 switch (effectVal>>4) {
+                  case 0x3: // vibrato waveform
+                    switch (effectVal&3) {
+                      case 0x0: // sine
+                        p->data[j][effectCol[k]++]=0xe3;
+                        p->data[j][effectCol[k]++]=0x00;
+                        break;
+                      case 0x1: // ramp down
+                        p->data[j][effectCol[k]++]=0xe3;
+                        p->data[j][effectCol[k]++]=0x05;
+                        break;
+                      case 0x2: // square
+                      case 0x3:
+                        p->data[j][effectCol[k]++]=0xe3;
+                        p->data[j][effectCol[k]++]=0x06;
+                        break;
+                    }
+                  break;
                   case 0x5: // fine tune
                     p->data[j][effectCol[k]++]=0xe5;
                     p->data[j][effectCol[k]++]=(effectVal&15)<<4;


### PR DESCRIPTION
- Special effects for S3M, XM and IT have commentary added on
- S3x/E4x (vibrato waveform) was implemented for S3M, XM, MOD and IT (with some fine print: namely, OpenMPT hacks not implemented, and no retrigger/continuous settings)
- S77-S7C (volume/panning/pitch envelope off/on) and SAy (sample offset (high nibble)) was implemented in IT. Yes, panning envelopes do indeed consume two effects to implement, mostly because the macros are split into two.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
