### PR TITLE
Correct a typo where the wrong effect ID was used for vibrato waveform

### DIFF
--- a/src/engine/fileOps/mod.cpp
+++ b/src/engine/fileOps/mod.cpp
@@ -356,16 +356,16 @@ bool DivEngine::loadMod(unsigned char* file, size_t len) {
                 case 2: // single note slide down
                   writeFxCol(fxTyp-1+0xf1,fxVal);
                   break;
-                case 0x3: // vibrato waveform
+                case 4: // vibrato waveform
                   switch (fxVal&3) {
-                    case 0x0: // sine
+                    case 0: // sine
                       writeFxCol(0xe3,0x00);
                       break;
-                    case 0x1: // ramp down
+                    case 1: // ramp down
                       writeFxCol(0xe3,0x05);
                       break;
-                    case 0x2: // square
-                    case 0x3: 
+                    case 2: // square
+                    case 3: 
                       writeFxCol(0xe3,0x06);
                       break;
                   }

--- a/src/engine/fileOps/xm.cpp
+++ b/src/engine/fileOps/xm.cpp
@@ -1147,7 +1147,7 @@ bool DivEngine::loadXM(unsigned char* file, size_t len) {
               case 0xe: // special...
                 // TODO: implement the rest
                 switch (effectVal>>4) {
-                  case 0x3: // vibrato waveform
+                  case 0x4: // vibrato waveform
                     switch (effectVal&3) {
                       case 0x0: // sine
                         p->data[j][effectCol[k]++]=0xe3;


### PR DESCRIPTION
E4x is the correct ID, not E3x, for MOD and XM.
Additionally, updated the coding style for MOD to be more consistent with the pre-existing code, namely by not using hex for the effect IDs being checked.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
