### PR TITLE
Add notifySampleChanged in dispatch and engine

### DIFF
--- a/src/engine/dispatch.h
+++ b/src/engine/dispatch.h
@@ -918,6 +918,11 @@ class DivDispatch {
     virtual void notifyWaveChange(int wave);
 
     /**
+     * notify sample change.
+     */
+    virtual void notifySampleChange(int sample);
+
+    /**
      * notify addition of an instrument.
      */
     virtual void notifyInsAddition(int sysID);

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -283,6 +283,14 @@ void DivEngine::notifyWaveChange(int wave) {
   BUSY_END;
 }
 
+void DivEngine::notifySampleChange(int sample) {
+  BUSY_BEGIN;
+  for (int i=0; i<song.systemLen; i++) {
+    disCont[i].dispatch->notifySampleChange(sample);
+  }
+  BUSY_END;
+}
+
 int DivEngine::loadSampleROM(String path, ssize_t expectedSize, unsigned char*& ret) {
   ret=NULL;
   if (path.empty()) {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -747,6 +747,8 @@ class DivEngine {
     void notifyInsChange(int ins);
     // notify wavetable change
     void notifyWaveChange(int wave);
+    // notify sample change
+    void notifySampleChange(int sample);
 
     // dispatch a command
     int dispatchCmd(DivCommand c);

--- a/src/engine/platform/abstract.cpp
+++ b/src/engine/platform/abstract.cpp
@@ -160,7 +160,11 @@ void DivDispatch::notifyInsChange(int ins) {
 
 }
 
-void DivDispatch::notifyWaveChange(int ins) {
+void DivDispatch::notifyWaveChange(int wave) {
+
+}
+
+void DivDispatch::notifySampleChange(int sample) {
 
 }
 

--- a/src/engine/platform/multipcm.cpp
+++ b/src/engine/platform/multipcm.cpp
@@ -516,6 +516,10 @@ void DivPlatformMultiPCM::notifyInsChange(int ins) {
   }
 }
 
+void DivPlatformMultiPCM::notifySampleChange(int sample) {
+  renderInstruments();
+}
+
 void DivPlatformMultiPCM::notifyInsAddition(int sysID) {
   renderInstruments();
 }
@@ -654,8 +658,6 @@ void DivPlatformMultiPCM::renderSamples(int sysID) {
   memCompo=DivMemoryComposition();
   memCompo.name="Sample Memory";
 
-  renderInstruments();
-
   size_t memPos=0x1800;
   int sampleCount=parent->song.sampleLen;
   if (sampleCount>512) {
@@ -709,6 +711,7 @@ void DivPlatformMultiPCM::renderSamples(int sysID) {
     pcmMemLen=memPos+256;
     memCompo.used=pcmMemLen;
   }
+  renderInstruments();
   memCompo.capacity=getSampleMemCapacity(0);
 }
 

--- a/src/engine/platform/multipcm.h
+++ b/src/engine/platform/multipcm.h
@@ -120,6 +120,7 @@ class DivPlatformMultiPCM: public DivDispatch {
     void toggleRegisterDump(bool enable);
     void setFlags(const DivConfig& flags);
     void notifyInsChange(int ins);
+    void notifySampleChange(int sample);
     void notifyInsAddition(int sysID);
     void notifyInsDeletion(void* ins);
     int getPortaFloor(int ch);

--- a/src/engine/platform/opl.h
+++ b/src/engine/platform/opl.h
@@ -186,6 +186,8 @@ class DivPlatformOPL: public DivDispatch {
     void acquire_ymfm2(short** buf, size_t len);
     void acquire_ymfm1(short** buf, size_t len);
   
+    void renderInstruments();
+  
   public:
     void acquire(short** buf, size_t len);
     int dispatch(DivCommand c);
@@ -211,6 +213,7 @@ class DivPlatformOPL: public DivDispatch {
     void toggleRegisterDump(bool enable);
     void setFlags(const DivConfig& flags);
     void notifyInsChange(int ins);
+    void notifySampleChange(int sample);
     void notifyInsDeletion(void* ins);
     int getPortaFloor(int ch);
     void poke(unsigned int addr, unsigned short val);

--- a/src/gui/dataList.cpp
+++ b/src/gui/dataList.cpp
@@ -279,6 +279,7 @@ void FurnaceGUI::sampleListItem(int i, int dir, int asset) {
     curSample=i;
     samplePos=0;
     updateSampleTex=true;
+    notifySampleChange=true;
     lastAssetType=2;
   }
   if (ImGui::IsItemHovered() && !mobileUI) {
@@ -309,6 +310,7 @@ void FurnaceGUI::sampleListItem(int i, int dir, int asset) {
     curSample=i;
     samplePos=0;
     updateSampleTex=true;
+    notifySampleChange=true;
     lastAssetType=2;
     ImGui::PushStyleColor(ImGuiCol_Text,uiColors[GUI_COLOR_TEXT]);
     if (ImGui::MenuItem(_("edit"))) {

--- a/src/gui/doAction.cpp
+++ b/src/gui/doAction.cpp
@@ -946,6 +946,7 @@ void FurnaceGUI::doAction(int what) {
           MARK_MODIFIED;
         }
         updateSampleTex=true;
+        notifySampleChange=true;
       }
       break;
     case GUI_ACTION_WAVE_LIST_MOVE_UP:
@@ -1003,6 +1004,7 @@ void FurnaceGUI::doAction(int what) {
         MARK_MODIFIED;
       }
       updateSampleTex=true;
+      notifySampleChange=true;
       break;
     case GUI_ACTION_SAMPLE_LIST_DUPLICATE:
       if (curSample>=0 && curSample<(int)e->song.sample.size()) {
@@ -1037,6 +1039,7 @@ void FurnaceGUI::doAction(int what) {
           MARK_MODIFIED;
         }
         updateSampleTex=true;
+        notifySampleChange=true;
       }
       break;
     case GUI_ACTION_SAMPLE_LIST_OPEN:
@@ -1062,6 +1065,7 @@ void FurnaceGUI::doAction(int what) {
         curSample--;
         wantScrollListSample=true;
         updateSampleTex=true;
+        notifySampleChange=true;
         MARK_MODIFIED;
       }
       break;
@@ -1070,6 +1074,7 @@ void FurnaceGUI::doAction(int what) {
         curSample++;
         wantScrollListSample=true;
         updateSampleTex=true;
+        notifySampleChange=true;
         MARK_MODIFIED;
       }
       break;
@@ -1081,6 +1086,7 @@ void FurnaceGUI::doAction(int what) {
         curSample--;
       }
       updateSampleTex=true;
+      notifySampleChange=true;
       break;
     case GUI_ACTION_SAMPLE_LIST_EDIT:
       sampleEditOpen=true;
@@ -1089,11 +1095,13 @@ void FurnaceGUI::doAction(int what) {
       if (--curSample<0) curSample=0;
       wantScrollListSample=true;
       updateSampleTex=true;
+      notifySampleChange=true;
       break;
     case GUI_ACTION_SAMPLE_LIST_DOWN:
       if (++curSample>=(int)e->song.sample.size()) curSample=((int)e->song.sample.size())-1;
       wantScrollListSample=true;
       updateSampleTex=true;
+      notifySampleChange=true;
       break;
     case GUI_ACTION_SAMPLE_LIST_PREVIEW:
       e->previewSample(curSample);
@@ -1183,6 +1191,7 @@ void FurnaceGUI::doAction(int what) {
       e->lockEngine([this,sample,start,end]() {
         sample->strip(start,end);
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1235,6 +1244,7 @@ void FurnaceGUI::doAction(int what) {
       sampleSelStart=pos;
       sampleSelEnd=pos+sampleClipboardLen;
       updateSampleTex=true;
+      notifySampleChange=true;
       MARK_MODIFIED;
       break;
     }
@@ -1266,6 +1276,7 @@ void FurnaceGUI::doAction(int what) {
       sampleSelEnd=pos+sampleClipboardLen;
       if (sampleSelEnd>(int)sample->samples) sampleSelEnd=sample->samples;
       updateSampleTex=true;
+      notifySampleChange=true;
       MARK_MODIFIED;
       break;
     }
@@ -1303,6 +1314,7 @@ void FurnaceGUI::doAction(int what) {
       sampleSelEnd=pos+sampleClipboardLen;
       if (sampleSelEnd>(int)sample->samples) sampleSelEnd=sample->samples;
       updateSampleTex=true;
+      notifySampleChange=true;
       MARK_MODIFIED;
       break;
     }
@@ -1368,6 +1380,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1399,6 +1412,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1430,6 +1444,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1459,6 +1474,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1475,6 +1491,7 @@ void FurnaceGUI::doAction(int what) {
 
         sample->strip(start,end);
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1493,6 +1510,7 @@ void FurnaceGUI::doAction(int what) {
 
         sample->trim(start,end);
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1528,6 +1546,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1555,6 +1574,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1580,6 +1600,7 @@ void FurnaceGUI::doAction(int what) {
         }
 
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });
@@ -1713,6 +1734,7 @@ void FurnaceGUI::doAction(int what) {
         sample->loopEnd=end;
         sample->loop=true;
         updateSampleTex=true;
+        notifySampleChange=true;
 
         e->renderSamples(curSample);
       });

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -2848,6 +2848,7 @@ void FurnaceGUI::processDrags(int dragX, int dragY) {
           for (int i=x; i<=x1; i++) ((signed char*)sampleDragTarget)[i]=val;
         }
         updateSampleTex=true;
+        notifySampleChange=true;
       }
     } else { // select
       if (sampleSelStart<0) {
@@ -3952,26 +3953,22 @@ bool FurnaceGUI::loop() {
               }
               nextWindow=GUI_WINDOW_WAVE_LIST;
               MARK_MODIFIED;
-            } 
-            else if (!samples.empty()) 
-            {
+            } else if (!samples.empty()) {
               if (e->song.sampleLen!=sampleCountBefore) {
                 //e->renderSamplesP();
               }
-              if (!e->getWarnings().empty())
-              {
+              if (!e->getWarnings().empty()) {
                 showWarning(e->getWarnings(),GUI_WARN_GENERIC);
               }
               int sampleCount=-1;
-              for (DivSample* s: samples)
-              {
+              for (DivSample* s: samples) {
                 sampleCount=e->addSamplePtr(s);
               }
               //sampleCount=e->addSamplePtr(droppedSample);
-              if (sampleCount>=0 && settings.selectAssetOnLoad) 
-              {
+              if (sampleCount>=0 && settings.selectAssetOnLoad) {
                 curSample=sampleCount;
                 updateSampleTex=true;
+                notifySampleChange=true;
               }
               nextWindow=GUI_WINDOW_SAMPLE_LIST;
               MARK_MODIFIED;
@@ -4208,6 +4205,11 @@ bool FurnaceGUI::loop() {
     if (notifyWaveChange) {
       notifyWaveChange=false;
       e->notifyWaveChange(curWave);
+    }
+
+    if (notifySampleChange) {
+      notifySampleChange=false;
+      e->notifySampleChange(curSample);
     }
 
     eventTimeEnd=SDL_GetPerformanceCounter();
@@ -5456,6 +5458,7 @@ bool FurnaceGUI::loop() {
                       MARK_MODIFIED;
                     });
                     updateSampleTex=true;
+                    notifySampleChange=true;
                   } else {
                     showError(_("...but you haven't selected a sample!"));
                     delete samples[0];
@@ -7079,6 +7082,7 @@ bool FurnaceGUI::loop() {
                 MARK_MODIFIED;
               });
               updateSampleTex=true;
+              notifySampleChange=true;
             } else {
               showError(_("...but you haven't selected a sample!"));
               delete s;
@@ -8444,6 +8448,7 @@ FurnaceGUI::FurnaceGUI():
   sysDupEnd(false),
   noteInputPoly(true),
   notifyWaveChange(false),
+  notifySampleChange(false),
   wantScrollListIns(false),
   wantScrollListWave(false),
   wantScrollListSample(false),

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -1707,7 +1707,7 @@ class FurnaceGUI {
   bool vgmExportDirectStream, displayInsTypeList, displayWaveSizeList;
   bool portrait, injectBackUp, mobileMenuOpen, warnColorPushed;
   bool wantCaptureKeyboard, oldWantCaptureKeyboard, displayMacroMenu;
-  bool displayNew, displayExport, displayPalette, fullScreen, preserveChanPos, sysDupCloneChannels, sysDupEnd, noteInputPoly, notifyWaveChange;
+  bool displayNew, displayExport, displayPalette, fullScreen, preserveChanPos, sysDupCloneChannels, sysDupEnd, noteInputPoly, notifyWaveChange, notifySampleChange;
   bool wantScrollListIns, wantScrollListWave, wantScrollListSample;
   bool displayPendingIns, pendingInsSingle, displayPendingRawSample, snesFilterHex, modTableHex, displayEditString;
   bool displayPendingSamples, replacePendingSample;

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -3465,6 +3465,7 @@ void FurnaceGUI::insTabSample(DivInstrument* ins) {
         if (ImGui::InputInt(_("Sample bank slot##BANKSLOT"),&ins->x1_010.bankSlot,1,4)) { PARAMETER
           if (ins->x1_010.bankSlot<0) ins->x1_010.bankSlot=0;
           if (ins->x1_010.bankSlot>=7) ins->x1_010.bankSlot=7;
+          notifySampleChange=true;
         }
       }
     }
@@ -3478,6 +3479,7 @@ void FurnaceGUI::insTabSample(DivInstrument* ins) {
         id=fmt::sprintf("%d: %s",i,e->song.sample[i]->name);
         if (ImGui::Selectable(id.c_str(),ins->amiga.initSample==i)) { PARAMETER
           ins->amiga.initSample=i;
+          notifySampleChange=true;
         }
       }
       ImGui::EndCombo();

--- a/src/gui/newSong.cpp
+++ b/src/gui/newSong.cpp
@@ -289,6 +289,7 @@ void FurnaceGUI::drawNewSong() {
     orderCursor=-1;
     samplePos=0;
     updateSampleTex=true;
+    notifySampleChange=true;
     selStart=SelectionPoint();
     selEnd=SelectionPoint();
     cursor=SelectionPoint();

--- a/src/gui/sampleEdit.cpp
+++ b/src/gui/sampleEdit.cpp
@@ -655,6 +655,7 @@ void FurnaceGUI::drawSampleEdit() {
             sample->loopEnd=sample->samples;*/
           }
           updateSampleTex=true;
+          notifySampleChange=true;
           REFRESH_SAMPLE
         }
         popWarningColor();
@@ -687,6 +688,7 @@ void FurnaceGUI::drawSampleEdit() {
                   e->renderSamples(curSample);
                 });
                 updateSampleTex=true;
+                notifySampleChange=true;
                 MARK_MODIFIED;
               }
             }
@@ -707,6 +709,7 @@ void FurnaceGUI::drawSampleEdit() {
               sample->brrEmphasis=be;
               e->renderSamplesP(curSample);
               updateSampleTex=true;
+              notifySampleChange=true;
               MARK_MODIFIED;
             }
             if (ImGui::IsItemHovered()) {
@@ -724,6 +727,7 @@ void FurnaceGUI::drawSampleEdit() {
               sample->brrNoFilter=bf;
               e->renderSamplesP(curSample);
               updateSampleTex=true;
+              notifySampleChange=true;
               MARK_MODIFIED;
             }
             if (ImGui::IsItemHovered()) {
@@ -737,6 +741,7 @@ void FurnaceGUI::drawSampleEdit() {
               sample->dither=di;
               e->renderSamplesP(curSample);
               updateSampleTex=true;
+              notifySampleChange=true;
               MARK_MODIFIED;
             }
             if (ImGui::IsItemHovered()) {
@@ -869,6 +874,7 @@ void FurnaceGUI::drawSampleEdit() {
                 sample->loopMode=(DivSampleLoopMode)i;
                 e->renderSamplesP(curSample);
                 updateSampleTex=true;
+                notifySampleChange=true;
                 MARK_MODIFIED;
               }
             }
@@ -892,6 +898,7 @@ void FurnaceGUI::drawSampleEdit() {
               sample->loopStart=sample->loopEnd;
             }
             updateSampleTex=true;
+            notifySampleChange=true;
             REFRESH_SAMPLE
           }
           if (ImGui::IsItemActive()) {
@@ -933,6 +940,7 @@ void FurnaceGUI::drawSampleEdit() {
               sample->loopEnd=sample->samples;
             }
             updateSampleTex=true;
+            notifySampleChange=true;
             REFRESH_SAMPLE
           }
           if (ImGui::IsItemActive()) {
@@ -1107,6 +1115,7 @@ void FurnaceGUI::drawSampleEdit() {
             e->renderSamples(curSample);
           });
           updateSampleTex=true;
+          notifySampleChange=true;
           sampleSelStart=-1;
           sampleSelEnd=-1;
           MARK_MODIFIED;
@@ -1171,6 +1180,7 @@ void FurnaceGUI::drawSampleEdit() {
             e->renderSamples(curSample);
           });
           updateSampleTex=true;
+          notifySampleChange=true;
           sampleSelStart=-1;
           sampleSelEnd=-1;
           MARK_MODIFIED;
@@ -1238,6 +1248,7 @@ void FurnaceGUI::drawSampleEdit() {
             }
 
             updateSampleTex=true;
+            notifySampleChange=true;
 
             e->renderSamples(curSample);
           });
@@ -1291,6 +1302,7 @@ void FurnaceGUI::drawSampleEdit() {
             e->renderSamples(curSample);
           });
           updateSampleTex=true;
+          notifySampleChange=true;
           sampleSelStart=pos;
           sampleSelEnd=pos+silenceSize;
           MARK_MODIFIED;
@@ -1466,6 +1478,7 @@ void FurnaceGUI::drawSampleEdit() {
             }
 
             updateSampleTex=true;
+            notifySampleChange=true;
 
             e->renderSamples(curSample);
           });
@@ -1545,6 +1558,7 @@ void FurnaceGUI::drawSampleEdit() {
                 }
               }
               updateSampleTex=true;
+              notifySampleChange=true;
 
               e->renderSamples(curSample);
             });
@@ -2507,6 +2521,7 @@ void FurnaceGUI::doUndoSample() {
     if (sample->undo()==2) {
       e->renderSamples(curSample);
       updateSampleTex=true;
+      notifySampleChange=true;
     }
   });
 }
@@ -2519,6 +2534,7 @@ void FurnaceGUI::doRedoSample() {
     if (sample->redo()==2) {
       e->renderSamples(curSample);
       updateSampleTex=true;
+      notifySampleChange=true;
     }
   });
 }


### PR DESCRIPTION
This method/variables are for notify sample is changed/altered/added/removed.  can be called together with updateSampleTex for sample update.

multipcm: Fix possible desync with instrument and sample parameter

opl4: Split sample table render and sample data render, Add notifySampleChange for refresh sample parameters

also: Fix code style consistency.

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
