### PR TITLE
Proper tick rate for Watara Supervision preset.

### DIFF
--- a/src/gui/presets.cpp
+++ b/src/gui/presets.cpp
@@ -328,7 +328,8 @@ void FurnaceGUI::initSystemPresets() {
   ENTRY(
     "Watara Supervision", {
       CH(DIV_SYSTEM_SUPERVISION, 1.0f, 0, "")
-    }
+    },
+    "tickRate=50.81300813008130081301"
   );
   CATEGORY_END;
 


### PR DESCRIPTION
This is the actual framerate for the SV's screen.