### PR TITLE
added another compat flag for c64

### DIFF
--- a/src/engine/platform/c64.cpp
+++ b/src/engine/platform/c64.cpp
@@ -278,7 +278,9 @@ void DivPlatformC64::tick(bool sysTick) {
     }
     bool condition=chan[i].std.alg.will;
     DivInstrument* ins=parent->getIns(chan[i].ins,DIV_INS_C64);
-    if ((!ins->c64.filterIsAbs) || macroRace) {
+    if (filterOld) {
+      condition=chan[i].std.alg.had && (_i==2||macroRace);
+    } else if ((!ins->c64.filterIsAbs) || macroRace) {
       condition=chan[i].std.alg.had;
     }
     if (condition) { // new cutoff macro
@@ -929,6 +931,7 @@ void DivPlatformC64::setFlags(const DivConfig& flags) {
   no1EUpdate=flags.getBool("no1EUpdate",false);
   multiplyRel=flags.getBool("multiplyRel",false);
   macroRace=flags.getBool("macroRace",false);
+  filterOld=flags.getBool("filterOld",false);
   testAD=((flags.getInt("testAttack",0)&15)<<4)|(flags.getInt("testDecay",0)&15);
   testSR=((flags.getInt("testSustain",0)&15)<<4)|(flags.getInt("testRelease",0)&15);
   initResetTime=flags.getInt("initResetTime",2);

--- a/src/engine/platform/c64.h
+++ b/src/engine/platform/c64.h
@@ -91,7 +91,7 @@ class DivPlatformC64: public DivDispatch {
   int pcmCycle, lineRate;
   short cutoff_slide;
 
-  bool keyPriority, sidIs6581, needInitTables, no1EUpdate, multiplyRel, macroRace, noSoftPCM;
+  bool keyPriority, sidIs6581, needInitTables, no1EUpdate, multiplyRel, macroRace, filterOld, noSoftPCM;
   unsigned char chanOrder[3];
   unsigned char testAD, testSR;
 

--- a/src/gui/sysConf.cpp
+++ b/src/gui/sysConf.cpp
@@ -694,6 +694,7 @@ bool FurnaceGUI::drawSysConf(int chan, int sysPos, DivSystem type, DivConfig& fl
       bool no1EUpdate=flags.getBool("no1EUpdate",false);
       bool multiplyRel=flags.getBool("multiplyRel",false);
       bool macroRace=flags.getBool("macroRace",false);
+      bool filterOld=flags.getBool("filterOld",false);
       int testAttack=flags.getInt("testAttack",0);
       int testDecay=flags.getInt("testDecay",0);
       int testSustain=flags.getInt("testSustain",0);
@@ -779,6 +780,11 @@ bool FurnaceGUI::drawSysConf(int chan, int sysPos, DivSystem type, DivConfig& fl
         altered=true;
       }
 
+  
+      if (ImGui::Checkbox(_("Use old cutoff macro implementation (compatibility)"),&filterOld)) {
+        altered=true;
+      }
+
 
       if (altered) {
         e->lockSave([&]() {
@@ -787,6 +793,7 @@ bool FurnaceGUI::drawSysConf(int chan, int sysPos, DivSystem type, DivConfig& fl
           flags.set("no1EUpdate",no1EUpdate);
           flags.set("multiplyRel",multiplyRel);
           flags.set("macroRace",macroRace);
+          flags.set("filterOld",filterOld);
           flags.set("testAttack",testAttack);
           flags.set("testDecay",testDecay);
           flags.set("testSustain",testSustain);


### PR DESCRIPTION
<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
this commit adds a SID compat flag (in the chip itself, not in the compat flags menu) that fixes a bug that Roostersox told me about the filter macros (like in [4xxx_test2.fur.zip](https://github.com/user-attachments/files/24374753/4xxx_test2.fur.zip)). It's in "Use old cutoff macro implementation (compatibility)" in the SID chip settings btw.