### PR TITLE
Extend PC engine frequency range to 1 - 4096

### DIFF
--- a/src/engine/platform/pce.cpp
+++ b/src/engine/platform/pce.cpp
@@ -378,10 +378,10 @@ void DivPlatformPCE::tick(bool sysTick) {
       }
       // clamp the final period...
       if (chan[i].freq<1) chan[i].freq=1;
-      if (chan[i].freq>4095) chan[i].freq=4095;
+      if (chan[i].freq>4096) chan[i].freq=4096;
       // ...and write it
       chWrite(i,0x02,chan[i].freq&0xff);
-      chWrite(i,0x03,chan[i].freq>>8);
+      chWrite(i,0x03,(chan[i].freq>>8)&0xf);
 
       // if we're in noise mode, calculate the noise pitch value.
       if (i>=4) {
@@ -411,7 +411,7 @@ void DivPlatformPCE::tick(bool sysTick) {
   }
   // if we have a scheduled LFO register update, do it now.
   if (updateLFO) {
-    rWrite(0x08,lfoSpeed);
+    rWrite(0x08,lfoSpeed); // TODO: 0 is treated to 256 in chip
     rWrite(0x09,lfoMode);
     updateLFO=false;
   }


### PR DESCRIPTION
0 treated to 4096 in chip, Same in LFO speed (256 in this case)

see also: https://github.com/tildearrow/furnace/blob/master/src/engine/platform/sound/pce_psg.cpp#L156

<!--
NOTICE: if you are contributing a new system, please be sure to ask tildearrow first in order to get system IDs allocated!
Do NOT Force-Push after submitting Pull Request! If you do so, your pull request will be closed.
-->
