### PR TITLE
small macro envelope/lfo adjustments

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -869,6 +869,7 @@ void FurnaceGUI::autoDetectSystem() {
 }
 
 void FurnaceGUI::setCurIns(int newIns) {
+  insEditMacroInsChanged=true;
   curIns=newIns;
   memset(multiIns,-1,7*sizeof(int));
 }
@@ -9021,6 +9022,9 @@ FurnaceGUI::FurnaceGUI():
   prevInsData(NULL),
   cachedCurInsPtr(NULL),
   insEditMayBeDirty(false),
+  insEditMacroEnvBottom(0),
+  insEditMacroEnvTop(0),
+  insEditMacroInsChanged(false),
   pendingLayoutImport(NULL),
   pendingLayoutImportLen(0),
   pendingLayoutImportStep(0),

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2411,6 +2411,8 @@ class FurnaceGUI {
   DivInstrument cachedCurIns;
   DivInstrument* cachedCurInsPtr;
   bool insEditMayBeDirty;
+  int insEditMacroEnvBottom, insEditMacroEnvTop; // TODO: WHAT DO I DO WITH THIS
+  bool insEditMacroInsChanged;
 
   unsigned char* pendingLayoutImport;
   size_t pendingLayoutImportLen;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -2411,7 +2411,7 @@ class FurnaceGUI {
   DivInstrument cachedCurIns;
   DivInstrument* cachedCurInsPtr;
   bool insEditMayBeDirty;
-  int insEditMacroEnvBottom, insEditMacroEnvTop; // TODO: WHAT DO I DO WITH THIS
+  int insEditMacroEnvBottom, insEditMacroEnvTop;
   bool insEditMacroInsChanged;
 
   unsigned char* pendingLayoutImport;

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2327,6 +2327,15 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
     }
     ImGui::PopStyleVar();
   } else {
+    const auto adjustParam=[](int& value, int oldBot, int oldTop, int newBot, int newTop) {
+      // Warning! It must be true that oldBot<=oldTop and newBot<=newTop.
+      double oldAmp=fabs((double)oldTop-oldBot);
+      double newAmp=fabs((double)newTop-newBot);
+      double normalized=(double)(value-oldBot)/oldAmp;
+      value=(normalized*newAmp)+newBot;
+      value=CLAMP(value,newBot,newTop); // make sure it's in the range
+    };
+
     if (i.macro->open&2) {
       const bool compact=(availableWidth<300.0f*dpiScale);
       bool adsrAdjust=false; // set to true if the range has been changed, so values can be readjusted
@@ -2364,7 +2373,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         ImGui::TableNextColumn();
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
         if (ImGui::InputInt("##MATop",&insEditMacroEnvTop,1,16)) {}
-        if (ImGui::IsItemDeactivated()) {
+        if (ImGui::IsItemDeactivated()) { PARAMETER
           i.macro->val[1]=CLAMP(insEditMacroEnvTop,i.min,i.max);
           insEditMacroEnvTop=i.macro->val[1];
 
@@ -2380,15 +2389,6 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         const int adsrTop=MAX(i.macro->val[0],i.macro->val[1]);
         const int adsrRange=abs(adsrTop-adsrBottom);
         const int adsrParamMax=(adsrRange<<8)|0xff;
-
-        const auto adjustParam=[](int& value, int oldBot, int oldTop, int newBot, int newTop) {
-          // Warning! It must be true that oldBot<=oldTop and newBot<=newTop.
-          double oldAmp=fabs((double)oldTop-oldBot);
-          double newAmp=fabs((double)newTop-newBot);
-          double normalized=(double)(value-oldBot)/oldAmp;
-          value=(normalized*newAmp)+newBot;
-          value=CLAMP(value,newBot,newTop); // make sure it's in the range
-        };
 
         // if the range has changed, we must adjust all parameters to make sure they're in range.
         if (adsrAdjust) {
@@ -2582,7 +2582,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
     }
     if (i.macro->open&4) {
       const bool compact=(availableWidth<300.0f*dpiScale);
-      bool lfoClamp=false;
+      bool lfoAdjust=false; // set to true if the range has been changed, so values can be readjusted
       if (ImGui::BeginTable("MacroLFO",compact?2:4)) {
         ImGui::TableSetupColumn("c0",ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("c1",ImGuiTableColumnFlags_WidthStretch,0.3);
@@ -2591,18 +2591,22 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           ImGui::TableSetupColumn("c3",ImGuiTableColumnFlags_WidthStretch,0.3);
         }
 
+        const int oldLfoBottom=i.macro->val[0];
+        const int oldLfoTop=i.macro->val[1];
+        updateRangeInputs();
+
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();
         ImGui::Text(_("Bottom"));
         ImGui::TableNextColumn();
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-        if (ImGui::InputInt("##MABottom",&i.macro->val[0],1,16)) { PARAMETER
-          if (i.macro->val[0]<i.min) i.macro->val[0]=i.min;
-          if (i.macro->val[0]>i.max) i.macro->val[0]=i.max;
+        if (ImGui::InputInt("##MABottom",&insEditMacroEnvBottom,1,16)) {}
+        if (ImGui::IsItemDeactivated()) { PARAMETER
+          i.macro->val[0]=CLAMP(insEditMacroEnvTop,i.min,i.max);
+          insEditMacroEnvTop=i.macro->val[0];
 
-          // clamp parameters to new range
-          lfoClamp=true;
+          lfoAdjust=true;
         }
 
         if (compact) ImGui::TableNextRow();
@@ -2611,26 +2615,29 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         ImGui::Text(_("Top"));
         ImGui::TableNextColumn();
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-        if (ImGui::InputInt("##MATop",&i.macro->val[1],1,16)) { PARAMETER
-          if (i.macro->val[1]<i.min) i.macro->val[1]=i.min;
-          if (i.macro->val[1]>i.max) i.macro->val[1]=i.max;
+        if (ImGui::InputInt("##MATop",&insEditMacroEnvTop,1,16)) {}
+        if (ImGui::IsItemDeactivated()) { PARAMETER
+          i.macro->val[1]=CLAMP(insEditMacroEnvTop,i.min,i.max);
+          insEditMacroEnvTop=i.macro->val[1];
 
-          // clamp parameters to new range
-          lfoClamp=true;
+          lfoAdjust=true;
         }
+
+        const auto calcParamMax=[](int bottom, int top, int shape) {
+          int range=abs(top-bottom);
+          return (shape==2)?65536:((range<<8)|0xff);
+        };
+
+        const int oldLfoShape=i.macro->val[12];
+        const int oldLfoParamMax=calcParamMax(oldLfoBottom,oldLfoTop,oldLfoShape);
 
         const int lfoBottom=i.macro->val[0];
         const int lfoTop=i.macro->val[1];
         const int lfoShape=i.macro->val[12];
-        const int lfoRange=abs(lfoTop-lfoBottom);
-        int lfoParamMax=(lfoShape==2)?65536:((lfoRange<<8)|0xff);
+        int lfoParamMax=calcParamMax(lfoBottom,lfoTop,lfoShape);
 
-        // if the range has changed, we must confine all parameters to make
-        // sure they're in range.
-        if (lfoClamp) {
-          // speed
-          if (i.macro->val[11]<0) i.macro->val[11]=0;
-          if (i.macro->val[11]>(lfoParamMax>>1)) i.macro->val[11]=lfoParamMax>>1;
+        if (lfoAdjust) {
+          adjustParam(i.macro->val[11],0,oldLfoParamMax>>1,0,lfoParamMax>>1); // speed
         }
 
         ImGui::TableNextRow();
@@ -2673,18 +2680,14 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           if (i.macro->val[12]<0) i.macro->val[12]=0;
           if (i.macro->val[12]>2) i.macro->val[12]=2;
 
-          // we must clamp in case the shape becomes square or not
-          lfoClamp=true;
-          lfoParamMax=(lfoShape==2)?32768:((lfoRange<<8)|0xff);
+          // an adjust is requested here in case the user has changed the LFO shape (square uses an accumulator from 0 to 65535 and disregards the range)
+          lfoAdjust=true;
+          lfoParamMax=calcParamMax(lfoBottom,lfoTop,i.macro->val[12]);
         } rightClickable
 
-        // a second clamp is performed here in case the user has changed the
-        // LFO shape (square uses an accumulator from 0 to 65535 and disregards
-        // the range)
-        if (lfoClamp) {
-          // speed
-          if (i.macro->val[11]<0) i.macro->val[11]=0;
-          if (i.macro->val[11]>(lfoParamMax>>1)) i.macro->val[11]=lfoParamMax>>1;
+        // adjust again with the potential new lfoParamMax
+        if (lfoAdjust) {
+          adjustParam(i.macro->val[11],0,oldLfoParamMax>>1,0,lfoParamMax>>1); // speed
         }
 
         ImGui::EndTable();

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2113,6 +2113,17 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
   static float bit30Indicator[256];
   static bool doHighlight[256];
 
+  const auto updateRangeInputs=[&]() {
+    // Update range inputs to match the current instrument, if the instrument has changed.
+    // It's a lambda because it needs to be called later on, or else the values might not have been initialized yet.
+    // FIXME: are there any other cases that may modify these values, other than "current instrument changed"?
+    if (insEditMacroInsChanged) {
+      insEditMacroEnvBottom=i.macro->val[0];
+      insEditMacroEnvTop=i.macro->val[1];
+      insEditMacroInsChanged=false;
+    }
+  };
+
   if ((i.macro->open&6)==0) {
     for (int j=0; j<256; j++) {
       bit30Indicator[j]=0;
@@ -2318,7 +2329,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
   } else {
     if (i.macro->open&2) {
       const bool compact=(availableWidth<300.0f*dpiScale);
-      bool adsrAdjust=false;
+      bool adsrAdjust=false; // set to true if the range has been changed, so values can be readjusted
       if (ImGui::BeginTable("MacroADSR",compact?2:4)) {
         ImGui::TableSetupColumn("c0",ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("c1",ImGuiTableColumnFlags_WidthStretch,0.3);
@@ -2330,6 +2341,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
 
         int oldBot=i.macro->val[0];
         int oldTop=i.macro->val[1];
+        updateRangeInputs();
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
@@ -2337,11 +2349,11 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         ImGui::Text(_("Bottom"));
         ImGui::TableNextColumn();
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-        if (ImGui::InputInt("##MABottom",&i.macro->val[0],1,16)) { PARAMETER
-          if (i.macro->val[0]<i.min) i.macro->val[0]=i.min;
-          if (i.macro->val[0]>i.max) i.macro->val[0]=i.max;
+        if (ImGui::InputInt("##MABottom",&insEditMacroEnvBottom,1,16)) {}
+        if (ImGui::IsItemDeactivated()) { PARAMETER
+          i.macro->val[0]=CLAMP(insEditMacroEnvBottom,i.min,i.max);
+          insEditMacroEnvTop=i.macro->val[0];
 
-          // clamp parameters to new range
           adsrAdjust=true;
         }
 
@@ -2351,11 +2363,11 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         ImGui::Text(_("Top"));
         ImGui::TableNextColumn();
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-        if (ImGui::InputInt("##MATop",&i.macro->val[1],1,16)) { PARAMETER
-          if (i.macro->val[1]<i.min) i.macro->val[1]=i.min;
-          if (i.macro->val[1]>i.max) i.macro->val[1]=i.max;
+        if (ImGui::InputInt("##MATop",&insEditMacroEnvTop,1,16)) {}
+        if (ImGui::IsItemDeactivated()) {
+          i.macro->val[1]=CLAMP(insEditMacroEnvTop,i.min,i.max);
+          insEditMacroEnvTop=i.macro->val[1];
 
-          // clamp parameters to new range
           adsrAdjust=true;
         }
 
@@ -2375,10 +2387,10 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           double newAmp=fabs((double)newTop-newBot);
           double normalized=(double)(value-oldBot)/oldAmp;
           value=(normalized*newAmp)+newBot;
+          value=CLAMP(value,newBot,newTop); // make sure it's in the range
         };
 
-        // if the range has changed, we must confine all parameters to make
-        // sure they're in range.
+        // if the range has changed, we must adjust all parameters to make sure they're in range.
         if (adsrAdjust) {
           adjustParam(i.macro->val[2],0,oldAdsrParamMax,0,adsrParamMax); // attack
           adjustParam(i.macro->val[4],0,oldAdsrParamMax,0,adsrParamMax); // decay

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2623,6 +2623,10 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           lfoAdjust=true;
         }
 
+        if (lfoAdjust) {
+          adjustParam(i.macro->val[11],0,oldLfoParamMax>>1,0,lfoParamMax>>1); // speed
+        }
+
         const auto calcParamMax=[](int bottom, int top, int shape) {
           int range=abs(top-bottom);
           return (shape==2)?65536:((range<<8)|0xff);

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2318,7 +2318,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
   } else {
     if (i.macro->open&2) {
       const bool compact=(availableWidth<300.0f*dpiScale);
-      bool adsrClamp=false;
+      bool adsrAdjust=false;
       if (ImGui::BeginTable("MacroADSR",compact?2:4)) {
         ImGui::TableSetupColumn("c0",ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("c1",ImGuiTableColumnFlags_WidthStretch,0.3);
@@ -2342,7 +2342,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           if (i.macro->val[0]>i.max) i.macro->val[0]=i.max;
 
           // clamp parameters to new range
-          adsrClamp=true;
+          adsrAdjust=true;
         }
 
         if (compact) ImGui::TableNextRow();
@@ -2356,10 +2356,8 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           if (i.macro->val[1]>i.max) i.macro->val[1]=i.max;
 
           // clamp parameters to new range
-          adsrClamp=true;
+          adsrAdjust=true;
         }
-
-        struct Foo {};
 
         const int oldAdsrBottom=MIN(oldBot,oldTop);
         const int oldAdsrTop=MAX(oldBot,oldTop);
@@ -2372,7 +2370,7 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         const int adsrParamMax=(adsrRange<<8)|0xff;
 
         const auto adjustParam=[](int& value, int oldBot, int oldTop, int newBot, int newTop) {
-          // TODO: what happens if bot>top?
+          // Warning! It must be true that oldBot<=oldTop and newBot<=newTop.
           double oldAmp=fabs((double)oldTop-oldBot);
           double newAmp=fabs((double)newTop-newBot);
           double normalized=(double)(value-oldBot)/oldAmp;
@@ -2381,12 +2379,12 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
 
         // if the range has changed, we must confine all parameters to make
         // sure they're in range.
-        if (adsrClamp) {
+        if (adsrAdjust) {
           adjustParam(i.macro->val[2],0,oldAdsrParamMax,0,adsrParamMax); // attack
           adjustParam(i.macro->val[4],0,oldAdsrParamMax,0,adsrParamMax); // decay
           adjustParam(i.macro->val[7],0,oldAdsrParamMax,0,adsrParamMax); // sustain decay
           adjustParam(i.macro->val[8],0,oldAdsrParamMax,0,adsrParamMax); // release
-          adjustParam(i.macro->val[5],oldBot,oldTop,adsrBottom,adsrTop); // sustain level
+          adjustParam(i.macro->val[5],oldAdsrBottom,oldAdsrTop,adsrBottom,adsrTop); // sustain level
         }
 
         ImGui::TableNextRow();

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2636,10 +2636,6 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         const int lfoShape=i.macro->val[12];
         int lfoParamMax=calcParamMax(lfoBottom,lfoTop,lfoShape);
 
-        if (lfoAdjust) {
-          adjustParam(i.macro->val[11],0,oldLfoParamMax>>1,0,lfoParamMax>>1); // speed
-        }
-
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2328,6 +2328,9 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         }
         //ImGui::TableSetupColumn("c4",ImGuiTableColumnFlags_WidthStretch,0.4);
 
+        int oldBot=i.macro->val[0];
+        int oldTop=i.macro->val[1];
+
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();
@@ -2356,33 +2359,34 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           adsrClamp=true;
         }
 
+        struct Foo {};
+
+        const int oldAdsrBottom=MIN(oldBot,oldTop);
+        const int oldAdsrTop=MAX(oldBot,oldTop);
+        const int oldAdsrRange=abs(oldAdsrTop-oldAdsrBottom);
+        const int oldAdsrParamMax=(oldAdsrRange<<8)|0xff;
+
         const int adsrBottom=MIN(i.macro->val[0],i.macro->val[1]);
         const int adsrTop=MAX(i.macro->val[0],i.macro->val[1]);
         const int adsrRange=abs(adsrTop-adsrBottom);
         const int adsrParamMax=(adsrRange<<8)|0xff;
 
+        const auto adjustParam=[](int& value, int oldBot, int oldTop, int newBot, int newTop) {
+          // TODO: what happens if bot>top?
+          double oldAmp=fabs((double)oldTop-oldBot);
+          double newAmp=fabs((double)newTop-newBot);
+          double normalized=(double)(value-oldBot)/oldAmp;
+          value=(normalized*newAmp)+newBot;
+        };
+
         // if the range has changed, we must confine all parameters to make
         // sure they're in range.
         if (adsrClamp) {
-          // attack
-          if (i.macro->val[2]<0) i.macro->val[2]=0;
-          if (i.macro->val[2]>adsrParamMax) i.macro->val[2]=adsrParamMax;
-
-          // decay
-          if (i.macro->val[4]<0) i.macro->val[4]=0;
-          if (i.macro->val[4]>adsrParamMax) i.macro->val[4]=adsrParamMax;
-
-          // sustain decay
-          if (i.macro->val[7]<0) i.macro->val[7]=0;
-          if (i.macro->val[7]>adsrParamMax) i.macro->val[7]=adsrParamMax;
-
-          // release
-          if (i.macro->val[8]<0) i.macro->val[8]=0;
-          if (i.macro->val[8]>adsrParamMax) i.macro->val[8]=adsrParamMax;
-
-          // sustain level
-          if (i.macro->val[5]<adsrBottom) i.macro->val[5]=adsrBottom;
-          if (i.macro->val[5]>adsrTop) i.macro->val[5]=adsrTop;
+          adjustParam(i.macro->val[2],0,oldAdsrParamMax,0,adsrParamMax); // attack
+          adjustParam(i.macro->val[4],0,oldAdsrParamMax,0,adsrParamMax); // decay
+          adjustParam(i.macro->val[7],0,oldAdsrParamMax,0,adsrParamMax); // sustain decay
+          adjustParam(i.macro->val[8],0,oldAdsrParamMax,0,adsrParamMax); // release
+          adjustParam(i.macro->val[5],oldBot,oldTop,adsrBottom,adsrTop); // sustain level
         }
 
         ImGui::TableNextRow();

--- a/src/gui/insEdit.cpp
+++ b/src/gui/insEdit.cpp
@@ -2623,10 +2623,6 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
           lfoAdjust=true;
         }
 
-        if (lfoAdjust) {
-          adjustParam(i.macro->val[11],0,oldLfoParamMax>>1,0,lfoParamMax>>1); // speed
-        }
-
         const auto calcParamMax=[](int bottom, int top, int shape) {
           int range=abs(top-bottom);
           return (shape==2)?65536:((range<<8)|0xff);
@@ -2639,6 +2635,10 @@ void FurnaceGUI::drawMacroEdit(FurnaceGUIMacroDesc& i, int totalFit, float avail
         const int lfoTop=i.macro->val[1];
         const int lfoShape=i.macro->val[12];
         int lfoParamMax=calcParamMax(lfoBottom,lfoTop,lfoShape);
+
+        if (lfoAdjust) {
+          adjustParam(i.macro->val[11],0,oldLfoParamMax>>1,0,lfoParamMax>>1); // speed
+        }
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();


### PR DESCRIPTION
Basically, auto-adjust values automatically so changing the top/bottom values doesn't ""corrupt"" the other parameters.

- [x] initial "proportional" adjustment (on envelope macro);
- [x] do adjustment only after the input box is finished (or when +/- is pressed) - https://github.com/tildearrow/furnace/pull/2833/commits/0c920073f5fee365708990a32fcaf77ce5d6d3c9;
- [x] make it work on lfo macro as well - https://github.com/tildearrow/furnace/pull/2833/commits/4e562207dc1a6e2e6afba3bd4d39c49077f2e59b;