### PR TITLE
Keeps selection in pattern while scrolling using "Move by Coarse Step"

### DIFF
--- a/src/gui/pattern.cpp
+++ b/src/gui/pattern.cpp
@@ -1657,7 +1657,15 @@ void FurnaceGUI::drawPattern() {
           xAmount*=MAX(1,editStepCoarse);
           yAmount*=MAX(1,editStepCoarse);
         }
+        bool hasSelection=!(selStart.xCoarse==selEnd.xCoarse && selStart.xFine==selEnd.xFine && selStart.y==selEnd.y && selStart.order==selEnd.order);
+        auto savedSelStart=selStart;
+        auto savedSelEnd=selEnd;
+
         moveCursor(xAmount,yAmount,false);
+        if (hasSelection) {
+          selStart=savedSelStart;
+          selEnd=savedSelEnd;
+        }
       }
     }
 


### PR DESCRIPTION
however theres a new bug now,  where if you've made a selection in one order, but then move to another order to make another selection, it instead moves and drags the first selection. i dont know how to fix this easily lol