### PR TITLE
Fix missing .md link in song-info documentation

### DIFF
--- a/doc/2-interface/song-info.md
+++ b/doc/2-interface/song-info.md
@@ -9,4 +9,4 @@ all of this metadata will be included in a VGM export. this isn't the case for a
 
 - **Tuning (A-4)**: set tuning based on the note A-4, which should be 440 in most cases. opening an Amiga MOD will set it to 436 for hardware compatibility.
 
-to change song speeds/parameters or edit sub-song information, see the [subsongs.md](subsongs) and [speed.md](speed) sections of this manual.
+to change song speeds/parameters or edit sub-song information, see the [subsongs.md](subsongs.md) and [speed.md](speed.md) sections of this manual.

--- a/doc/2-interface/song-info.md
+++ b/doc/2-interface/song-info.md
@@ -9,4 +9,4 @@ all of this metadata will be included in a VGM export. this isn't the case for a
 
 - **Tuning (A-4)**: set tuning based on the note A-4, which should be 440 in most cases. opening an Amiga MOD will set it to 436 for hardware compatibility.
 
-to change song speeds/parameters or edit sub-song information, see the [subsongs.md](subsongs.md) and [speed.md](speed.md) sections of this manual.
+to change song speeds/parameters or edit sub-song information, see the [subsongs](subsongs.md) and [speed](speed.md) sections of this manual.


### PR DESCRIPTION
I was browsing the furnace tracker documentation, and I've found a 404 link in the song-info .md. It is supposed to point to speed.md and subsongs.md but it is missing the `.md` extension so if you click it in the github .md documentation it leads to a 404.